### PR TITLE
fernets not a hash, has to have a string

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -219,7 +219,7 @@ module Identity
       if token && secret
         begin
           verifier = Fernet.verifier(secret, token)
-          referral = CGI.escape(verifier.data[:referrer])
+          referral = CGI.escape(verifier.data["referrer"])
         rescue Exception => e
           Identity.log(:referral_slug_error => true,
             :exception => e.class.name, :message => e.message)


### PR DESCRIPTION
Was trying to access it as if it was a hash.... it is not.
