### PR TITLE
Set Heroku cookies on refresh dance completion

### DIFF
--- a/lib/identity/auth_helpers.rb
+++ b/lib/identity/auth_helpers.rb
@@ -178,8 +178,8 @@ module Identity
     def set_heroku_cookie(key, value)
       response.set_cookie(key,
         domain:    heroku_cookie_domain,
+        expires:   Time.now + 2592000,
         http_only: true,
-        max_age:   2592000,
         value:     value)
     end
 


### PR DESCRIPTION
Identity's cookie gets reset every time the user visits it, but the
Heroku session cookies can be much shorter-lived. Cause the refresh
dance to set these values, therefore refreshing them much more
frequently.
