### PR TITLE
Allow a refresh cycle to be performed against ID

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -185,9 +185,10 @@ module Identity
               body: URI.encode_www_form({
                 code:          params[:code],
                 client_secret: params[:client_secret],
-                grant_type:    "authorization_code",
+                grant_type:    params[:grant_type] || "authorization_code",
+                refresh_token: params[:refresh_token],
                 session_id:    @cookie.session_id,
-              }))
+              }.reject { |k, v| v == nil }))
           end
 
           token = MultiJson.decode(res.body)


### PR DESCRIPTION
As described in [the OAuth 2 spec](http://tools.ietf.org/html/rfc6749#section-6). Identity currently performs its own refresh cycle against the API, but doesn't properly handle a refresh cycle performed by clients against its own API.
