### PR TITLE
Configurable heroku cookie domain (no longer auto-detected)

### DIFF
--- a/lib/identity/auth_helpers.rb
+++ b/lib/identity/auth_helpers.rb
@@ -75,7 +75,7 @@ module Identity
 
     def delete_heroku_cookie(key)
       response.delete_cookie(key,
-        domain: heroku_cookie_domain)
+        domain: Config.heroku_cookie_domain)
     end
 
     # Performs the complete OAuth dance against the Heroku API in order to
@@ -193,7 +193,7 @@ module Identity
 
     def set_heroku_cookie(key, value)
       response.set_cookie(key,
-        domain:    heroku_cookie_domain,
+        domain:    Config.heroku_cookie_domain,
         expires:   Time.now + 2592000,
         http_only: true,
         value:     value)
@@ -207,13 +207,6 @@ module Identity
       uri_params = Rack::Utils.parse_query(uri.query).merge(params)
       uri.query  = Rack::Utils.build_query(uri_params)
       uri.to_s
-    end
-
-    def heroku_cookie_domain
-      domain = request.host.split(".")[1..-1].join(".")
-
-      # for something like "localhost", just use the base domain
-      domain != "" ? domain : request.host
     end
   end
 end

--- a/lib/identity/config.rb
+++ b/lib/identity/config.rb
@@ -26,6 +26,10 @@ module Identity
       ENV["HEROKU_OAUTH_SECRET"] || raise("missing=HEROKU_OAUTH_SECRET")
     end
 
+    def heroku_cookie_domain
+      ENV["HEROKU_DOMAIN"] || ".heroku.com"
+    end
+
     def mixpanel_token
       ENV["MIXPANEL_TOKEN"]
     end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -12,6 +12,7 @@ describe Identity::Auth do
   end
 
   before do
+    stub(Identity::Config).heroku_cookie_domain { ".example.org" }
     stub_heroku_api
     rack_mock_session.clear_cookies
   end


### PR DESCRIPTION
Attempt to fix some consistency problem we've been seeing around
Identity's interaction with other Heroku web properties.
