### PR TITLE
Use session ID as nonce

### DIFF
--- a/lib/identity/auth_helpers.rb
+++ b/lib/identity/auth_helpers.rb
@@ -146,16 +146,13 @@ module Identity
         raise "missing=expires_in"    unless @cookie.access_token_expires_at
         raise "missing=refresh_token" unless @cookie.refresh_token
 
-        # WARNING: some users appear to have nil nonces
-        #raise "missing=session_nonce" unless nonce
-
         # cookies with a domain scoped to all heroku domains, used to set a
         # session nonce value so that consumers can recognize when the logged
         # in user has changed
         set_heroku_cookie("heroku_session", "1")
-        set_heroku_cookie("heroku_session_nonce", nonce)
+        set_heroku_cookie("heroku_session_nonce", @cookie.session_id)
 
-        log :oauth_dance_complete, session_id: @cookie.session_id, nonce: nonce
+        log :oauth_dance_complete, session_id: @cookie.session_id
       end
     end
 

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -242,7 +242,7 @@ describe Identity::Auth do
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"
       assert_equal "1",
         rack_mock_session.cookie_jar["heroku_session"]
-      assert_equal "0a80ac35-b9d8-4fab-9261-883bea77ad3a",
+      assert_equal "8bb579ed-e3a4-41ed-9c1c-719e96618f71",
         rack_mock_session.cookie_jar["heroku_session_nonce"]
     end
 

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -88,7 +88,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
   post "/oauth/sessions" do
     status(201)
     MultiJson.encode({
-      id:          "session123@heroku.com",
+      id:          "8bb579ed-e3a4-41ed-9c1c-719e96618f71",
       description: "Session @ 127.0.0.1",
       expires_in:  2592000,
     })
@@ -120,7 +120,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
         expires_in: 2592000,
       },
       session: {
-        id:         "session123@heroku.com",
+        id:         "8bb579ed-e3a4-41ed-9c1c-719e96618f71",
       },
       user: {
         session_nonce: "0a80ac35-b9d8-4fab-9261-883bea77ad3a",


### PR DESCRIPTION
A pretty major bug came up in that as far as I can tell, session nonces
aren't being generated correctly for new users anymore. Instead of a
nonce, this pull re-uses the identifier of the session generated for the
current login, which is guaranteed to have a value according to how ID
authenticates.

This value should be as cryptographically secure as anything else we use
as it's also a UUID, and is guaranteed to be fresh everytime a new login
takes place on ID. I may not fully comprehend all the requirements here
though, so let me know if I'm missing something. /cc @tmaher @pedro
