### PR TITLE
Remove GET /account response; no longer needed

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -20,25 +20,6 @@ module Identity
     end
 
     namespace "/account" do
-      # The omniauth strategy used to make a call to /account after a
-      # successful authentication, so proxy this through to core.
-      # Authentication occurs via a header with a bearer token.
-      #
-      # Remove this as soon as we get Devcenter and Dashboard upgraded.
-      get do
-        return 401 if !request.env["HTTP_AUTHORIZATION"]
-        api = HerokuAPI.new(user: nil, request_ids: request_ids, version: 2,
-          authorization: request.env["HTTP_AUTHORIZATION"],
-            ip: request.ip,
-          # not necessarily V3, respond with whatever the client asks for
-          headers: {
-            "Accept" => request.env["HTTP_ACCEPT"] || "application/json"
-          })
-        res = api.get(path: "/account", expects: 200)
-        content_type(:json)
-        res.body
-      end
-
       post do
         begin
           api = HerokuAPI.new(ip: request.ip, request_ids: request_ids,

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -16,13 +16,6 @@ describe Identity::Account do
     rack_mock_session.clear_cookies
   end
 
-  describe "GET /account" do
-    it "responds with 401 without a session" do
-      get "/account"
-      assert_equal 401, last_response.status
-    end
-  end
-
   describe "POST /account" do
     it "creates an account and renders a notice" do
       post "/account", email: "kerry@heroku.com"


### PR DESCRIPTION
This was used for deprecated OAuth strategies, and it looks like it's no
longer used.

Fixes #37.
