### PR TITLE
Use `rake test` to run tests; seed environment in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ heroku git:remote -a id-production -r production
 Note: requires api-admin (install/build from http://github.com/heroku/api-admin)
 
 ```
-foreman run bin/test
+rake test
 git push staging master
 api-test-login --staging
 git push production master
@@ -75,7 +75,7 @@ Identity's logs are also drained to the [platform Splunk installation](https://s
 ## Test
 
 ``` bash
-bin/test
+rake test
 ```
 
 ## Installations

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+end
+
+task :default => :test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,11 @@
+# seed the environment
+ENV["COOKIE_ENCRYPTION_KEY"] = "another-super-secret-ultra-secure-key"
+ENV["DASHBOARD_URL"]         = "https://dashboard.heroku.com"
+ENV["HEROKU_API_URL"]        = "https://id.heroku.com"
+ENV["HEROKU_OAUTH_ID"]       = "46307a2b-0397-4739-b2b7-2f67d1cff597"
+ENV["HEROKU_OAUTH_SECRET"]   = "b6c6aa58-3219-4642-add9-6d8008b268f6"
 # set before using Bundler
-ENV["RACK_ENV"] = "test"
+ENV["RACK_ENV"]              = "test"
 
 require "bundler/setup"
 Bundler.require(:default, :test)


### PR DESCRIPTION
Also seed environment in `test_helper` so that no `.env` is needed to
run the tests.

I'll leave bin/test in for a bit longer, but deprecating it in favor of
this.
