### PR TITLE
Add tabindex properties for all fields in login/signup/password reset

### DIFF
--- a/views/account/password/reset.slim
+++ b/views/account/password/reset.slim
@@ -16,10 +16,10 @@
       input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
       fieldset
         .field
-          input#reset_email.text type="text" name="email" size="46" value="email address"
+          input#reset_email.text type="text" name="email" size="46" value="email address" tabindex="1"
       fieldset.submit
         p
           a href="/login" Log In
           | &nbsp;or&nbsp;
           a href="/signup" Sign Up
-        input.submit type="submit" value="Reset Password"
+        input.submit type="submit" value="Reset Password" tabindex="2"

--- a/views/login.slim
+++ b/views/login.slim
@@ -6,14 +6,14 @@
     fieldset
       .field
         label for="email" Email
-        input#email.text type="email" name="email" placeholder="email address"
+        input#email.text type="email" name="email" placeholder="email address" tabindex="1"
       .field
         label for="password" Password
-        input#password.text.password type="password" name="password" placeholder="password"
+        input#password.text.password type="password" name="password" placeholder="password" tabindex="2"
     fieldset.submit
       p
         a href="/account/password/reset" Reset Password
-      input.submit type="submit" name="commit" value="Log In"
+      input.submit type="submit" name="commit" value="Log In" tabindex="3"
 
 a href="/signup" id="message"
   | Getting started with Heroku is easy.

--- a/views/signup.slim
+++ b/views/signup.slim
@@ -12,9 +12,9 @@
     fieldset
       div.field
         label for="invitation_email" Email
-        input#invitation_email.text type="text" name="email" autofocus="autofocus" autocapitalize="off" placeholder="Enter your email address"
+        input#invitation_email.text type="text" name="email" autofocus="autofocus" autocapitalize="off" placeholder="Enter your email address" tabindex="1"
     fieldset.submit
-      input.submit type="submit" value="Sign Up"
+      input.submit type="submit" value="Sign Up" tabindex="2"
 a#message.signup href="/login"
   | Already have an account?
   span Log In


### PR DESCRIPTION
The login page was causing problems in Chrome, which is not as smart
about ordering elements for tab stop.

Fixes #21.
