### PR TITLE
Fix name of `scope` field to get authorizations working again

### DIFF
--- a/lib/identity/auth_helpers.rb
+++ b/lib/identity/auth_helpers.rb
@@ -34,7 +34,7 @@ module Identity
 
         authorization = authorizations.detect { |a|
           a["client"] && a["client"]["id"] == params["client_id"] &&
-            a["scopes"] == (params["scope"] || ["global"])
+            a["scope"] == (params["scope"] || ["global"])
         }
 
         # fall back to legacy_id (for now)

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -59,7 +59,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
     status(201)
     MultiJson.encode({
       id:         "68e3146b-be7e-4520-b60b-c4f06623084f",
-      scopes:     ["global"],
+      scope:      ["global"],
       created_at: Time.now,
       updated_at: Time.now,
       access_token: nil,


### PR DESCRIPTION
Should fix some problems that non-trusted clients are experiencing.
