### PR TITLE
Move helpers to `Helpers::Identity` namespace

### DIFF
--- a/lib/identity.rb
+++ b/lib/identity.rb
@@ -8,9 +8,9 @@ require_relative "identity/excon_instrumentor"
 require_relative "identity/fernet_cookie_coder"
 require_relative "identity/heroku_api"
 
-require_relative "identity/log_helpers"
-require_relative "identity/api_helpers"
-require_relative "identity/auth_helpers"
+require_relative "identity/helpers/log"
+require_relative "identity/helpers/api"
+require_relative "identity/helpers/auth"
 
 require_relative "identity/middleware/heroku_cookie"
 

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -7,9 +7,9 @@ module Identity
     register ErrorHandling
     register Sinatra::Namespace
 
-    include APIHelpers
-    include AuthHelpers
-    include LogHelpers
+    include Helpers::API
+    include Helpers::Auth
+    include Helpers::Log
 
     configure do
       set :views, "#{Config.root}/views"

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -4,9 +4,9 @@ module Identity
     register ErrorHandling
     register Sinatra::Namespace
 
-    include APIHelpers
-    include AuthHelpers
-    include LogHelpers
+    include Helpers::API
+    include Helpers::Auth
+    include Helpers::Log
 
     configure do
       set :views, "#{Config.root}/views"

--- a/lib/identity/cookie_fixer.rb
+++ b/lib/identity/cookie_fixer.rb
@@ -15,7 +15,7 @@ module Identity
   module CookieFixer
     def self.registered(app)
       app.instance_eval do
-        include LogHelpers
+        include Helpers::Log
       end
 
       app.after do

--- a/lib/identity/helpers/api.rb
+++ b/lib/identity/helpers/api.rb
@@ -1,5 +1,5 @@
-module Identity
-  module APIHelpers
+module Identity::Helpers
+  module API
     def decode_error(body)
       # error might look like:
       #   1. { "id":..., "message":... } (V3)

--- a/lib/identity/helpers/log.rb
+++ b/lib/identity/helpers/log.rb
@@ -1,5 +1,5 @@
-module Identity
-  module LogHelpers
+module Identity::Helpers
+  module Log
     def log(action, data={}, &block)
       data.merge! app: "identity", request_id: request_ids
 


### PR DESCRIPTION
This project is growing a bit so let's start using some select
namespaces where they make sense. This moves helper class into
`Helpers::Identity`.
