### PR TITLE
Standarize :token everywhere (instead of hash)

### DIFF
--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -69,7 +69,7 @@ describe Identity::Account do
     end
   end
 
-  describe "GET /account/accept/:id/:hash" do
+  describe "GET /account/accept/:id/:token" do
     it "shows a form to finish signup" do
       get "/account/accept/123/456abc"
       assert_equal 200, last_response.status
@@ -92,7 +92,7 @@ meta content="3;url=https://dashboard.heroku.com" http-equiv="refresh"
     end
   end
 
-  describe "GET /account/email/confirm/:hash" do
+  describe "GET /account/email/confirm/:token" do
     it "requires login" do
       get "/account/email/confirm/c45685917ef644198a0fececa10d479a"
       assert_equal 302, last_response.status
@@ -109,9 +109,9 @@ meta content="3;url=https://dashboard.heroku.com" http-equiv="refresh"
         last_response.headers["Location"]
     end
 
-    it "shows a helpful page for a hash that wasn't found" do
+    it "shows a helpful page for a token that wasn't found" do
       stub_heroku_api do
-        post("/confirm_change_email/:hash") {
+        post("/confirm_change_email/:token") {
           raise Excon::Errors::NotFound, "Not found"
         }
       end
@@ -148,7 +148,7 @@ meta content="3;url=https://dashboard.heroku.com" http-equiv="refresh"
     end
   end
 
-  describe "GET /account/password/reset/:hash" do
+  describe "GET /account/password/reset/:token" do
     it "renders a password reset form" do
       stub_heroku_api
       get "/account/password/reset/c45685917ef644198a0fececa10d479a"
@@ -156,7 +156,7 @@ meta content="3;url=https://dashboard.heroku.com" http-equiv="refresh"
     end
   end
 
-  describe "POST /account/password/reset/:hash" do
+  describe "POST /account/password/reset/:token" do
     it "changes a password and redirects to login" do
       stub_heroku_api
       post "/account/password/reset/c45685917ef644198a0fececa10d479a",

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -37,15 +37,15 @@ If you don't receive an email, and it's not in your spam folder, this could mean
     })
   end
 
-  get "/auth/finish_reset_password/:hash" do |hash|
+  get "/auth/finish_reset_password/:token" do |token|
     MultiJson.encode({ email: "kerry@heroku.com" })
   end
 
-  post "/auth/finish_reset_password/:hash" do |hash|
+  post "/auth/finish_reset_password/:token" do |token|
     MultiJson.encode({ email: "kerry@heroku.com" })
   end
 
-  post "/confirm_change_email/:hash" do |hash|
+  post "/confirm_change_email/:token" do |token|
     302
   end
 

--- a/views/account/accept.slim
+++ b/views/account/accept.slim
@@ -5,7 +5,7 @@
   h2 Welcome to Heroku
   form method="post" action="/account/accept/ok"
     input type="hidden" name="id" value=@user["id"]
-    input type="hidden" name="hash" value=@user["hash"]
+    input type="hidden" name="token" value=@user["token"]
     input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
     .overview
       - if @user["invited_by"] && @user["invited_by"]["email"]


### PR DESCRIPTION
Just uses `:token` everywhere.
