### PR TITLE
CSRF parsing can cause a bad stack trace

### DIFF
--- a/lib/identity.rb
+++ b/lib/identity.rb
@@ -7,6 +7,7 @@ require_relative "identity/excon_instrumentor"
 require_relative "identity/fernet_cookie_coder"
 require_relative "identity/heroku_api"
 require_relative "identity/heroku_cookie"
+require_relative "identity/rescue_errors"
 
 require_relative "identity/helpers/log"
 require_relative "identity/helpers/api"

--- a/lib/identity/csrf.rb
+++ b/lib/identity/csrf.rb
@@ -14,10 +14,6 @@ module Identity
         expected_token: env['rack.session']['csrf.token'],
         id: env["REQUEST_IDS"]
       [403, { 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
-    rescue Exception => e
-      Identity.log(:exception, class: e.class.name, message: e.message,
-        csrf: true, backtrace: e.backtrace.inspect)
-      [500, { 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
     end
   end
 end

--- a/lib/identity/main.rb
+++ b/lib/identity/main.rb
@@ -1,5 +1,6 @@
 module Identity
   Main = Rack::Builder.new do
+    use Identity::RescueErrors
     use Rack::Instruments,
       context: { app: "identity" },
       response_request_id: true

--- a/lib/identity/rescue_errors.rb
+++ b/lib/identity/rescue_errors.rb
@@ -1,0 +1,15 @@
+module Identity
+  class RescueErrors
+    def initialize(app, opts={})
+      super(app, opts)
+    end
+
+    def call(env)
+      super(env)
+    rescue Exception => e
+      Identity.log(:exception, class: e.class.name, message: e.message,
+        backtrace: e.backtrace.inspect)
+      [500, { 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
+    end
+  end
+end


### PR DESCRIPTION
This trace showed up:

```
Puma caught this error: undefined method `size' for nil:NilClass 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/utils.rb:445:in `[]=' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/utils.rb:76:in 
`block in parse_query' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/utils.rb:66:in `each' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/utils.rb:66:in 
`parse_query' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/request.rb:263:in 
`cookies' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/cookie.rb:104:in 
`unpacked_cookie_data' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/cookie.rb:98:in 
`extract_session_id' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:43:in 
`load_session_id!' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:32:in 
`[]' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:262:in 
`current_session_id' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:268:in 
`session_exists?' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:107:in 
`exists?' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:122:in 
`load_for_read!' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:59:in 
`[]' 
/app/vendor/bundle/ruby/2.0.0/gems/rack_csrf-2.4.0/lib/rack/csrf.rb:64:in 
`token' 
/app/vendor/bundle/ruby/2.0.0/gems/rack_csrf-2.4.0/lib/rack/csrf.rb:37:in 
`call' 
/app/lib/identity/csrf.rb:9:in `call' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:205:in 
`context' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/session/abstract/id.rb:200:in 
`call' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/deflater.rb:13:in 
`call' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-ssl-1.3.2/lib/rack/ssl.rb:27:in 
`call' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-instruments-0.3.2/lib/rack/instruments.rb:52:in 
`block in call' 
/app/vendor/bundle/ruby/2.0.0/gems/slides-0.2.0/lib/slides.rb:19:in 
`log_array' 
/app/vendor/bundle/ruby/2.0.0/gems/slides-0.2.0/lib/slides.rb:7:in `log' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-instruments-0.3.2/lib/rack/instruments.rb:51:in 
`call' 
/app/vendor/bundle/ruby/2.0.0/gems/rack-1.4.1/lib/rack/builder.rb:134:in 
`call' 
/app/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:412:in 
`handle_request' 
/app/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:306:in 
`process_client' 
/app/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:215:in 
`block in run' 
/app/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/thread_pool.rb:94:in 
`call' 
/app/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/thread_pool.rb:94:in 
`block in spawn_thread'
```

Issues in parse_query around session.token reading. Catch the exception and return a 500.

/cc @brandur 
