### PR TITLE
Add `secret` value to `Rack::Session::Cookie` in tests for quiet Rack

### DIFF
--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -5,7 +5,7 @@ describe Identity::Account do
 
   def app
     Rack::Builder.new do
-      use Rack::Session::Cookie
+      use Rack::Session::Cookie, secret: "my-secret"
       use Rack::Flash
       run Identity::Account
     end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -5,7 +5,7 @@ describe Identity::Auth do
 
   def app
     Rack::Builder.new do
-      use Rack::Session::Cookie, domain: "example.org"
+      use Rack::Session::Cookie, domain: "example.org", secret: "my-secret"
       use Rack::Flash
       run Identity::Auth
     end


### PR DESCRIPTION
Unfortunately there doesn't seem to be a "my cookies are encrypted and
I'd like to opt out of this warning" option.
