### PR TITLE
Reject loading two-factor form if we haven't been through /login first

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -23,7 +23,11 @@ module Identity
       end
 
       get "/two-factor" do
-        slim :"two-factor", layout: :"layouts/zen_backdrop"
+        if @cookie.email && @cookie.password
+          slim :"two-factor", layout: :"layouts/zen_backdrop"
+        else
+          redirect to("/login")
+        end
       end
 
       # Creates a session for a user by receiving their username and password.

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -334,6 +334,12 @@ describe Identity::Auth do
         end
       end
 
+      it "redirects to /login if we have no email or password" do
+        get "/login/two-factor"
+        assert_equal 302, last_response.status
+        assert_match %r{/login$}, last_response.headers["Location"]
+      end
+
       it "redirects to /login/two-factor to prompt for the code" do
         post "/login", email: "kerry@heroku.com", password: "abcdefgh"
         assert_equal 302, last_response.status


### PR DESCRIPTION
Right now, anyone can go to https://id.heroku.com/login/two-factor and see the second factor form.
We shouldn't be able to display this form unless we've been redirected to it after entering an email and a password.

This fixes the problem by redirecting to /login if we don't yet have an email and a password stored in session.
