### PR TITLE
Add support for multiple experimental signup slugs

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -283,9 +283,11 @@ module Identity
     end
 
     def experimental_signup_slug?(slug)
+      return false unless slug
       # the split here cleans out the campaign stuff added in
       # #generate_referral_slug
-      slug && slug.split('?').first == Config.experimental_signup_slug
+      clean_slug = slug.split('?').first
+      Config.experimental_signup_slugs.include?(clean_slug)
     end
   end
 end

--- a/lib/identity/config.rb
+++ b/lib/identity/config.rb
@@ -22,8 +22,8 @@ module Identity
       ENV["EXPERIMENTAL_SIGNUP_URL"] || raise("missing=EXPERIMENTAL_SIGNUP_URL")
     end
 
-    def experimental_signup_slug
-      ENV["EXPERIMENTAL_SIGNUP_SLUG"]
+    def experimental_signup_slugs
+      ENV["EXPERIMENTAL_SIGNUP_SLUG"].to_s.split(',')
     end
 
     def heroku_oauth_id

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -76,7 +76,7 @@ describe Identity::Account do
     end
 
     it "redirects to experimental signup when appropriate" do
-      stub(Identity::Config).experimental_signup_slug { "experimental" }
+      stub(Identity::Config).experimental_signup_slugs { ["experimental"] }
       stub(Identity::Config).experimental_signup_url {
         "http://experiment.heroku.com"
       }
@@ -108,7 +108,7 @@ meta content="3;url=https://dashboard.heroku.com" http-equiv="refresh"
     end
 
     it "redirects to experimental signup when appropriate" do
-      stub(Identity::Config).experimental_signup_slug { "experimental" }
+      stub(Identity::Config).experimental_signup_slugs { ["experimental"] }
       stub(Identity::Config).experimental_signup_url {
         "https://experiment.heroku.com"
       }


### PR DESCRIPTION
This allows configuring several multiple experimental signup slugs by setting `ENV['EXPERIMENTAL_SIGNUP_SLUG']` as comma-separated strings.

The behaviour for all these slugs will be the same (redirect to signup.heroku.com when any experimental slug is found) but having several of them will allow us to track several signup pages separately.
