### PR TITLE
Redirect /signup/:slug to the signup app if the slug is experimental

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -244,8 +244,17 @@ module Identity
     end
 
     get "/signup/:slug" do |slug|
-      @cookie.signup_source = slug
-      slim :signup, layout: :"layouts/zen_backdrop"
+      # Try an "experimental" signup flow if the user matched a configured
+      # signup slug. Currently in use by Devcenter to improve the user
+      # on-boarding experience.
+      if experimental_signup_slug?(slug)
+        signup_url = "#{Config.experimental_signup_url}#{request.path}"
+        signup_url += "?#{request.query_string}" if params.any?
+        redirect to(signup_url)
+      else
+        @cookie.signup_source = slug
+        slim :signup, layout: :"layouts/zen_backdrop"
+      end
     end
 
     private

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -218,6 +218,16 @@ meta content="3;url=https://experiment.heroku.com/account/accept/ok" http-equiv=
   end
 
   describe "GET /signup/:slug" do
+    it "redirects to the signup app preserving query params if the slug is experimental" do
+      stub(Identity::Config).experimental_signup_slugs { ["experimental"] }
+      stub(Identity::Config).experimental_signup_url {
+        "https://experiment.heroku.com"
+      }
+      get "/signup/experimental?foo=bar"
+      assert_equal 302, last_response.status
+      assert_equal "https://experiment.heroku.com/signup/experimental?foo=bar", last_response.headers["Location"]
+    end
+
     it "shows a new account page" do
       get "/signup/facebook"
       assert_equal 200, last_response.status


### PR DESCRIPTION
This would allow Dev Center to slowly roll out the signup app by editing Identity's config vars for selected groups of slugs, instead of manually replacing links to identity with links to the experimental signup app.
