### PR TITLE
Support to redirect all signups to the signup app

### DIFF
--- a/lib/identity/config.rb
+++ b/lib/identity/config.rb
@@ -62,6 +62,10 @@ module Identity
       ENV["RACK_ENV"] == "production"
     end
 
+    def redirect_all_signups
+      !ENV["REDIRECT_ALL_SIGNUPS"].nil?
+    end
+
     def release
       @release ||= ENV["RELEASE"] || "1"
     end

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -115,6 +115,13 @@ describe Identity::Account do
       assert_equal "http://experiment.heroku.com/account/accept/123/456abc",
         last_response.headers["Location"]
     end
+
+    it "redirects to the same path in the signup app when redirect_all_signups is enabled" do
+      stub(Identity::Config).redirect_all_signups { true }
+      get "/account/accept/123/456abc"
+      assert_equal 302, last_response.status
+      assert_equal "#{Identity::Config.experimental_signup_url}/account/accept/123/456abc?from=id", last_response.headers["Location"]
+    end
   end
 
   describe "POST /account/accept/ok" do
@@ -147,6 +154,13 @@ meta content="3;url=https://dashboard.heroku.com" http-equiv="refresh"
       assert_match <<-eos.strip, last_response.body
 meta content="3;url=https://experiment.heroku.com/account/accept/ok" http-equiv="refresh"
       eos
+    end
+
+    it "redirects to the signup app when redirect_all_signups is enabled" do
+      stub(Identity::Config).redirect_all_signups { true }
+      post "/account/accept/ok"
+      assert_equal 302, last_response.status
+      assert_equal "#{Identity::Config.experimental_signup_url}/account/accept/ok?from=id", last_response.headers["Location"]
     end
   end
 
@@ -239,6 +253,13 @@ meta content="3;url=https://experiment.heroku.com/account/accept/ok" http-equiv=
       get "/signup"
       assert_equal 200, last_response.status
     end
+
+    it "redirects to the root of the experimental_signup_url when redirect_all_signups is enabled" do
+      stub(Identity::Config).redirect_all_signups { true }
+      get "/signup"
+      assert_equal 302, last_response.status
+      assert_equal "#{Identity::Config.experimental_signup_url}?from=id", last_response.headers["Location"]
+    end
   end
 
   describe "GET /signup/:slug" do
@@ -250,6 +271,13 @@ meta content="3;url=https://experiment.heroku.com/account/accept/ok" http-equiv=
       get "/signup/experimental?foo=bar"
       assert_equal 302, last_response.status
       assert_equal "https://experiment.heroku.com/signup/experimental?foo=bar", last_response.headers["Location"]
+    end
+
+    it "redirects to the same slug in the experimental_signup_url when redirect_all_signups is enabled" do
+      stub(Identity::Config).redirect_all_signups { true }
+      get "/signup/foo"
+      assert_equal 302, last_response.status
+      assert_equal "#{Identity::Config.experimental_signup_url}/foo?from=id", last_response.headers["Location"]
     end
 
     it "shows a new account page" do


### PR DESCRIPTION
Hey guys! Here is a proposal to move all signups to signup.h.c.

A `REDIRECT_ALL_SIGNUPS` config var in identity will activate the redirections, so we can revert to the current flow if we detect any problem. That complicates the code, but decouples this rollout from any other code updates that may be needed during that time.

So, when `REDIRECT_ALL_SIGNUPS` is present, incoming signups to id.h.c will be redirected as follows:
- https://id.heroku.com/signup -> https://signup.heroku.com/?from=id
- https://id.heroku.com/signup/:slug -> https://signup.heroku.com/:slug?from=id

The `?from=id` param will allow us to:
- track how many redirects we have
- handle them appropriately in signup.h.c

(Internally, when signup.h.c detects a `?from=id` parameter it will log the fact that it's a redirect from identity and apply a second redirect to clean the URL):
- signup.heroku.com/?from=id -> signup.heroku.com/identity (new campaign id)
- signup.heroku.com/foo?from=id -> signup.heroku.com/foo

We'll keep using id.h.c in the verification links for a while, so we can revert to the current flow if we detect issues. When `REDIRECT_ALL_SIGNUPS` is set, the following redirect will be applied:
- https://id.heroku.com/account/accept/:foo/:bar -> https://signup.heroku.com/account/accept/:foo/:bar?from=id

The "verify email and set password" form will keep being POSTed to id.h.c/accept/ok to log the user in. Once verified and logged in, the user will be redirected to signup.h.c/accept/ok if `REDIRECT_ALL_SIGNUPS` is set.

...and that's it. I think the changes above will cover all our existing use cases for signup.

Implementation-wise, I've tried to keep the changes small and simple, which in most cases implied adding ugly conditionals over existing ugly conditionals. Once we're confident with the move we'll be able to get rid of some of this code.

Looking forward to your feedback.
