### PR TITLE
Error on password expiry

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -73,8 +73,9 @@ module Identity
         rescue Excon::Errors::Unauthorized
           flash[:error] = "There was a problem with your login."
           redirect to("/login")
-        # client is suspended; show an appropriate message
-        rescue Identity::Errors::SuspendedAccount => e
+        # client is suspended or their password has expired; show an appropriate message
+        rescue Identity::Errors::PasswordExpired,
+               Identity::Errors::SuspendedAccount => e
           flash[:error] = e.message
           redirect to("/login")
         # client not yet authorized; show the user a confirmation dialog
@@ -239,6 +240,10 @@ module Identity
       # refresh token dance was unsuccessful
       rescue Excon::Errors::Unauthorized, Identity::Errors::NoSession
         @cookie.authorize_params = authorize_params
+        redirect to("/login")
+      rescue Identity::Errors::PasswordExpired,
+             Identity::Errors::SuspendedAccount => e
+        flash[:error] = e.message
         redirect to("/login")
       # client not yet authorized; show the user a confirmation dialog
       rescue Identity::Errors::UnauthorizedClient => e

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -2,6 +2,14 @@ module Identity::Errors
   class NoSession < StandardError
   end
 
+  class PasswordExpired < StandardError
+    attr_accessor :message
+
+    def initialize(msg)
+      @message = msg
+    end
+  end
+
   class UnauthorizedClient < StandardError
     attr_accessor :client
 

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -136,7 +136,10 @@ module Identity::Helpers
           auth = MultiJson.decode(res.body)
         rescue Excon::Errors::UnprocessableEntity => e
           err = MultiJson.decode(e.response.body)
-          if err['id'] == "suspended"
+          case err['id']
+          when 'password_expired'
+            raise Identity::Errors::PasswordExpired.new(err["message"])
+          when 'suspended'
             raise Identity::Errors::SuspendedAccount.new(err["message"])
           else
             raise e


### PR DESCRIPTION
Error on login or or re-authorization when a user's password has expired, and
dump them back to the login screen.

Also fixes a bug when a suspended account that was already logged in would
attempt to re-authorize (previously this resulted in a 500).
