### PR TITLE
Add a `created_at` field to initialized cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,6 @@ group :development, :test do
   #gem "debugger"
   gem "rack-test"
   gem "rr"
+  gem "timecop"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       tilt (~> 1.1)
     temple (0.5.5)
     tilt (1.3.3)
+    timecop (0.3.5)
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -107,5 +108,6 @@ DEPENDENCIES
   slim
   sprockets
   sprockets-sass
+  timecop
   webmock
   yui-compressor

--- a/lib/identity/cookie.rb
+++ b/lib/identity/cookie.rb
@@ -2,6 +2,8 @@ module Identity
   class Cookie
     def initialize(session)
       @session = session
+
+      self.created_at ||= Time.now
     end
 
     def access_token
@@ -33,6 +35,17 @@ module Identity
 
     def clear
       @session.clear
+    end
+
+    # not used yet, but will eventually be used to enforce a maximum duration
+    # on session lifetimes
+    def created_at
+      @session["created_at"] ? Time.parse(@session["created_at"]) : nil
+    end
+
+    def created_at=(created_at)
+      @session["created_at"] =
+        created_at ? created_at.iso8601 : nil
     end
 
     # used to store creds during two-factor auth

--- a/test/cookie_test.rb
+++ b/test/cookie_test.rb
@@ -1,0 +1,12 @@
+require_relative "test_helper"
+
+describe Identity::Cookie do
+  it "sets created_at on initialization" do
+    Timecop.freeze(Time.now) do
+      fake_session = {}
+      cookie = Identity::Cookie.new(fake_session)
+      assert_equal Time.now.to_i, cookie.created_at.to_i
+      assert_equal Time.now.iso8601, fake_session["created_at"]
+    end
+  end
+end


### PR DESCRIPTION
This will eventually be used to track total session duration.
