### PR TITLE
Send value of "Allow Access" along with authorize form POST

### DIFF
--- a/views/clients/authorize.slim
+++ b/views/clients/authorize.slim
@@ -40,4 +40,6 @@
 
     fieldset.split
       button.btn.btn-default.btn-lg href=@deny_url tabindex="2" Deny Access
-      button.btn.btn-primary.btn-lg type="submit" name="authorize" tabindex="1" Allow Access
+      / Note that a value of "Allow Access" should be kept here so that the
+      / server-side component can distinguish a confirmed form post.
+      button.btn.btn-primary.btn-lg type="submit" name="authorize" tabindex="1" value="Allow Access" Allow Access


### PR DESCRIPTION
The server-side component uses this value to distinguish a confirmed form post
to /oauth/authorize from any other kind of post that might have happened.
