### PR TITLE
Fix an error that was introduced in the text description

### DIFF
--- a/views/account/email/not_found.slim
+++ b/views/account/email/not_found.slim
@@ -5,4 +5,4 @@
     p Check the URL (there should be 10 - 20 digit hex key after /account/email/confirm/) and make sure you copied it in its entirety.  Or, you may have used it already, or requested another change.  In the latter case, find the most recent recent request in your email and use that.
     hr
     p
-      strong If all else fails, email <a href="mailto:support@heroku.com">support@heroku.com</a> for assistance.t@heroku.com</a> for assistance.
+      strong If all else fails, email <a href="mailto:support@heroku.com">support@heroku.com</a> for assistance.


### PR DESCRIPTION
Fixes an error in the text that I think was introduced by @ntassone in https://github.com/heroku/identity/commit/99bdbcfd873d12229def896ff90f475687a27f5c#diff-429c6191a58c04ffb7c7a207ef68d59a 

(CC @raul )

PS. @raul this screen isn't in the /design
PPS.  Reported by @dmathieu - thanks.
