### PR TITLE
Improve custom error handling + better expired password handling

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -73,9 +73,10 @@ module Identity
         rescue Excon::Errors::Unauthorized
           flash[:error] = "There was a problem with your login."
           redirect to("/login")
-        # client is suspended or their password has expired; show an appropriate message
-        rescue Identity::Errors::PasswordExpired,
-               Identity::Errors::SuspendedAccount => e
+        rescue Identity::Errors::PasswordExpired => e
+          flash[:error] = e.message
+          redirect to("/account/password/reset")
+        rescue Identity::Errors::SuspendedAccount => e
           flash[:error] = e.message
           redirect to("/login")
         # client not yet authorized; show the user a confirmation dialog
@@ -241,8 +242,10 @@ module Identity
       rescue Excon::Errors::Unauthorized, Identity::Errors::NoSession
         @cookie.authorize_params = authorize_params
         redirect to("/login")
-      rescue Identity::Errors::PasswordExpired,
-             Identity::Errors::SuspendedAccount => e
+      rescue Identity::Errors::PasswordExpired => e
+        flash[:error] = e.message
+        redirect to("/account/password/reset")
+      rescue Identity::Errors::SuspendedAccount => e
         flash[:error] = e.message
         redirect to("/login")
       # client not yet authorized; show the user a confirmation dialog

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -3,10 +3,16 @@ module Identity::Errors
   end
 
   class PasswordExpired < StandardError
+    # Override this message so that the user doesn't see a URL that they're
+    # supposed to visit. Instead, just take them directly to the write place.
+    MESSAGE = <<-eos.strip
+      Your password has expired. Please reset it.
+    eos
+
     attr_accessor :message
 
-    def initialize(msg)
-      @message = msg
+    def initialize
+      @message = MESSAGE
     end
   end
 

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -11,8 +11,10 @@ module Identity::Errors
 
     attr_accessor :message
 
-    def initialize
-      @message = MESSAGE
+    def initialize(_)
+      @message = <<-eos.strip
+        Your password has expired. Please reset it.
+      eos
     end
   end
 

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -3,15 +3,11 @@ module Identity::Errors
   end
 
   class PasswordExpired < StandardError
-    # Override this message so that the user doesn't see a URL that they're
-    # supposed to visit. Instead, just take them directly to the write place.
-    MESSAGE = <<-eos.strip
-      Your password has expired. Please reset it.
-    eos
-
     attr_accessor :message
 
     def initialize(_)
+      # Override this message so that the user doesn't see a URL that they're
+      # supposed to visit. Instead, just take them directly to the write place.
       @message = <<-eos.strip
         Your password has expired. Please reset it.
       eos

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -134,16 +134,6 @@ module Identity::Helpers
           end
 
           auth = MultiJson.decode(res.body)
-        rescue Excon::Errors::UnprocessableEntity => e
-          err = MultiJson.decode(e.response.body)
-          case err['id']
-          when 'password_expired'
-            raise Identity::Errors::PasswordExpired.new(err["message"])
-          when 'suspended'
-            raise Identity::Errors::SuspendedAccount.new(err["message"])
-          else
-            raise e
-          end
         end
 
         @cookie.session_id              = auth["session"]["id"]

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -331,7 +331,13 @@ describe Identity::Auth do
         # webmock doesn't handle Excon's :expects, so raise error directly
         # until it does
         post("/oauth/authorizations") {
-          raise(Excon::Errors::Unauthorized, "Unauthorized")
+          err = MultiJson.encode({
+            id: "unauthorized",
+            message: "you are not authorized"
+          })
+          response = OpenStruct.new(body: err)
+          raise Excon::Errors::Unauthorized.new(
+            "Unauthorized", nil, response)
         }
       end
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -80,7 +80,7 @@ describe Identity::Auth do
       assert_match /you are suspended/, last_response.body
     end
 
-    it "redirects to login when a user's password has expired" do
+    it "redirects to password reset when a user's password has expired" do
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"
 
       stub_heroku_api do
@@ -96,9 +96,7 @@ describe Identity::Auth do
       end
       post "/oauth/authorize", client_id: "dashboard"
       assert_equal 302, last_response.status
-      follow_redirect!
-      assert_equal 200, last_response.status
-      assert_match /password expired/, last_response.body
+      assert_match %r{/account/password/reset\z}, last_response.headers["Location"]
     end
 
     describe "for a delinquent account" do
@@ -367,7 +365,7 @@ describe Identity::Auth do
       assert_match /you are suspended/, last_response.body
     end
 
-    it "redirects to login when a user's password has expired" do
+    it "redirects to password reset when a user's password has expired" do
       stub_heroku_api do
         post("/oauth/authorizations") {
           err = MultiJson.encode({
@@ -381,9 +379,7 @@ describe Identity::Auth do
       end
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"
       assert_equal 302, last_response.status
-      follow_redirect!
-      assert_equal 200, last_response.status
-      assert_match /password expired/, last_response.body
+      assert_match %r{/account/password/reset\z}, last_response.headers["Location"]
     end
 
     describe "for accounts with two-factor enabled" do


### PR DESCRIPTION
Makes the code to intercept V3 error identifiers and convert them to custom error classes a little more generic and widespread.

Also, adds a custom error message for password expiry to avoid a non-linked URL in flash and redirects a user directly to the password reset page.

Fixes #132.