### PR TITLE
Add campaign slug to the signup link in the login page

### DIFF
--- a/views/login.slim
+++ b/views/login.slim
@@ -15,7 +15,7 @@
       input#password.form-control.password type="password" name="password" autocomplete="off" placeholder="Password" tabindex="2"
     button.btn.btn-primary.btn-lg.btn-block type="submit" name="commit" value="Log In" tabindex="3" Log In
 
-  a.panel-footer href="/signup"
+  a.panel-footer href="/signup/login"
     | New to Heroku? &nbsp;
     span Sign Up
 


### PR DESCRIPTION
We're interested on knowing how many signups come from the login page: adding a signup slug will allow us to track those.