### PR TITLE
Update SMS recovery page to show 8 digits

### DIFF
--- a/views/account/two-factor/recovery_sms.slim
+++ b/views/account/two-factor/recovery_sms.slim
@@ -8,11 +8,11 @@
     p.overview
       | We have sent an SMS to your phone number (
       b = @sms_number
-      |) with a 6-digit code to enter below.
+      |) with a 8-digit code to enter below.
     .form-group
-      label for="code" 6-digit recovery code
+      label for="code" 8-digit recovery code
       .input-icon.icon-sms
-      input#code.form-control type="text" name="code" size="6" autocomplete="off" autofocus="true" placeholder="6-digit sms code" tabindex="1"
+      input#code.form-control type="text" name="code" size="8" autocomplete="off" autofocus="true" placeholder="8-digit sms code" tabindex="1"
     button.btn.btn-primary.btn-lg.btn-block type="submit" name="commit" tabindex="2" Use SMS Code
 
   .panel-footer


### PR DESCRIPTION
SMS recovery codes have increased in length to 8 digits, this updates the page to reflect that.