### PR TITLE
Don't send an expired OAuth access token into refresh

### DIFF
--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -156,8 +156,8 @@ module Identity::Helpers
     def perform_oauth_refresh_dance
       log :oauth_refresh_dance do
         res = log :refresh_token do
-          api = Identity::HerokuAPI.new(pass: @cookie.access_token,
-            ip: request.ip, request_ids: request_ids, version: 3)
+          api = Identity::HerokuAPI.new(ip: request.ip,
+            request_ids: request_ids, version: 3)
           api.post(path: "/oauth/tokens", expects: 201,
             body: MultiJson.encode({
               client:        { secret: Identity::Config.heroku_oauth_secret },


### PR DESCRIPTION
Token refresh is accomplished using only:

1. A refresh token held in the user's cookie.
2. Identity's OAuth secret.

There's no need to send an (expired) access token into the API while trying to perform the refresh.