### PR TITLE
Handle 429 errors from API

### DIFF
--- a/lib/identity/error_handling.rb
+++ b/lib/identity/error_handling.rb
@@ -8,6 +8,7 @@ module Identity
       Excon::Errors::ServiceUnavailable,
       Excon::Errors::SocketError,
       Excon::Errors::Timeout,
+      Excon::Errors::TooManyRequests
     ]
 
     def self.registered(app)

--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -1,0 +1,37 @@
+require_relative "test_helper"
+
+describe Identity::ErrorHandling do
+  include Rack::Test::Methods
+
+  def app
+    Sinatra.new do
+      register Identity::ErrorHandling
+
+      set :views, "#{Identity::Config.root}/views"
+
+      get "/429" do
+        raise Excon::Errors::TooManyRequests.new("too many")
+      end
+
+      get "/503" do
+        raise Excon::Errors::Timeout.new("timeout")
+      end
+    end
+  end
+
+  describe "429" do
+    it "renders the 429 error page" do
+      get "/429"
+      assert_equal 429, last_response.status
+      assert_match /Too Many Requests/, last_response.body
+    end
+  end
+
+  describe "unavailable errors" do
+    it "renders the 503 error page" do
+      get "/503"
+      assert_equal 503, last_response.status
+      assert_match /Unavailable/, last_response.body
+    end
+  end
+end

--- a/views/errors/429.slim
+++ b/views/errors/429.slim
@@ -1,0 +1,6 @@
+- @title = "Too Many Requests"
+
+#notfound.panel
+  h3 Too Many Requests
+  .panel-body.panel-left
+    p You are currently making too many requests to Heroku. Please wait a while and try to log in again.


### PR DESCRIPTION
Currently when a user hitting identity is rate limited in API, we throw a 500 (and spam rollbar).
This fixes it to render the 503 error page, "API Unavailable", instead of "Internal Server Error", and no longer log them in Rollbar.

Ready for review @heroku/api 