### PR TITLE
Federated Identity take 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "bourbon"
 gem "coffee-script"
 gem "excon"
 gem "fernet"
+gem "jwt"
 gem "multi_json"
 gem "oj" # fast json
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     execjs (2.2.2)
     fernet (1.5)
     hike (1.2.1)
+    jwt (1.5.1)
     method_source (0.8.2)
     minitest (5.4.3)
     multi_json (1.10.1)
@@ -97,6 +98,7 @@ DEPENDENCIES
   coffee-script
   excon
   fernet
+  jwt
   minitest
   multi_json
   oj

--- a/lib/identity.rb
+++ b/lib/identity.rb
@@ -19,6 +19,7 @@ require_relative "identity/account"
 require_relative "identity/assets"
 require_relative "identity/auth"
 require_relative "identity/default"
+require_relative "identity/login_external"
 require_relative "identity/robots"
 
 require_relative "identity/main"

--- a/lib/identity/config.rb
+++ b/lib/identity/config.rb
@@ -14,10 +14,6 @@ module Identity
       ENV["DASHBOARD_URL"] || raise("missing=DASHBOARD_URL")
     end
 
-    def finalize_shared_secret
-      ENV["FINALIZE_SHARED_SECRET"]
-    end
-
     def heroku_api_url
       ENV["HEROKU_API_URL"] || raise("missing=HEROKU_API_URL")
     end
@@ -40,6 +36,10 @@ module Identity
 
     def google_tag_manager_account
       ENV["GOOGLE_TAG_MANAGER_ACCOUNT"]
+    end
+
+    def login_external_secret
+      ENV["LOGIN_EXTERNAL_SECRET"]
     end
 
     def old_cookie_encryption_key

--- a/lib/identity/config.rb
+++ b/lib/identity/config.rb
@@ -14,6 +14,10 @@ module Identity
       ENV["DASHBOARD_URL"] || raise("missing=DASHBOARD_URL")
     end
 
+    def finalize_shared_secret
+      ENV["FINALIZE_SHARED_SECRET"]
+    end
+
     def heroku_api_url
       ENV["HEROKU_API_URL"] || raise("missing=HEROKU_API_URL")
     end

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -136,17 +136,7 @@ module Identity::Helpers
           auth = MultiJson.decode(res.body)
         end
 
-        @cookie.session_id              = auth["session"]["id"]
-        @cookie.access_token            = auth["access_token"]["token"]
-        @cookie.access_token_expires_at =
-          Time.now + auth["access_token"]["expires_in"]
-        @cookie.refresh_token           = auth["refresh_token"]["token"]
-        @cookie.user_id                 = auth["user"]["id"]
-
-        # some basic sanity checks
-        raise "missing=access_token"  unless @cookie.access_token
-        raise "missing=expires_in"    unless @cookie.access_token_expires_at
-        raise "missing=refresh_token" unless @cookie.refresh_token
+        write_authentication_to_cookie auth
 
         log :oauth_dance_complete, session_id: @cookie.session_id, user: user
       end
@@ -178,6 +168,20 @@ module Identity::Helpers
 
         log :oauth_refresh_dance_complete, session_id: @cookie.session_id
       end
+
+    end
+
+    def write_authentication_to_cookie(auth)
+      expires_at = Time.now + auth["access_token"]["expires_in"]
+      @cookie.session_id              = auth["session"]["id"]
+      @cookie.access_token            = auth["access_token"]["token"]
+      @cookie.access_token_expires_at = expires_at
+      @cookie.refresh_token           = auth["refresh_token"].try(:[], "token")
+      @cookie.user_id                 = auth["user"]["id"]
+
+      # some basic sanity checks
+      raise "missing=access_token"  unless @cookie.access_token
+      raise "missing=expires_in"    unless @cookie.access_token_expires_at
     end
   end
 end

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -23,7 +23,7 @@ module Identity
     private
 
     def shared_key
-      Config.finalize_shared_secret
+      Config.login_external_secret
     end
   end
 end

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -1,3 +1,7 @@
+# This defines an endpoint for external services such as Fido (Federated
+# Identity) and signup.heroku.com so that they can use their own method for
+# authentication and set cookies in identity.
+# The endpoint is protected by a shared secret.
 module Identity
   class LoginExternal < Default
     register Sinatra::Namespace

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -1,0 +1,29 @@
+module Identity
+  class LoginExternal < Default
+    register Sinatra::Namespace
+    include Helpers::Auth
+
+    namespace "/login/external" do
+      before do
+        halt 404 unless shared_key
+      end
+
+      get do
+        token = params[:token]
+        auth, _ = JWT.decode(token, shared_key)
+        write_authentication_to_cookie auth
+        redirect to(Config.dashboard_url)
+      end
+
+      error JWT::DecodeError do
+        handle_error 401
+      end
+    end
+
+    private
+
+    def shared_key
+      Config.finalize_shared_secret
+    end
+  end
+end

--- a/lib/identity/main.rb
+++ b/lib/identity/main.rb
@@ -38,8 +38,9 @@ module Identity
       mount Account
       mount Assets
       mount Auth
-      mount Robots
       mount Design if Config.development?
+      mount LoginExternal
+      mount Robots
       run   Default # index + error handlers
     }
   end

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -20,7 +20,7 @@ describe Identity::Account do
 
   describe "shared key is not configured" do
     before do
-      stub(Identity::Config).finalize_shared_secret { nil }
+      stub(Identity::Config).login_external_secret { nil }
     end
 
     it "returns 404" do
@@ -33,7 +33,7 @@ describe Identity::Account do
     let(:shared_key){ "hello world secret token" }
 
     before do
-      stub(Identity::Config).finalize_shared_secret { shared_key }
+      stub(Identity::Config).login_external_secret { shared_key }
     end
 
     it "returns 401 if token is incorrect" do

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -1,0 +1,60 @@
+require_relative "test_helper"
+
+describe Identity::Account do
+  include Rack::Test::Methods
+
+  def app
+    Rack::Builder.new do
+      use Rack::Session::Cookie, domain: "example.org", secret: "my-secret"
+      run Identity::LoginExternal
+    end
+  end
+
+  def request_session
+    last_request.env["rack.session"]
+  end
+
+  before do
+    rack_mock_session.clear_cookies
+  end
+
+  describe "shared key is not configured" do
+    before do
+      stub(Identity::Config).finalize_shared_secret { nil }
+    end
+
+    it "returns 404" do
+      get "/login/extenal?token=123"
+      assert_equal 404, last_response.status
+    end
+  end
+
+  describe "shared key is configured" do
+    let(:shared_key){ "hello world secret token" }
+
+    before do
+      stub(Identity::Config).finalize_shared_secret { shared_key }
+    end
+
+    it "returns 401 if token is incorrect" do
+      get "/login/external?token=123"
+      assert_equal 401, last_response.status
+    end
+
+    describe "token is correct" do
+      let(:cookie_data){{ "foo" => "bar" }}
+      let(:token){ JWT.encode(cookie_data, shared_key, "HS256") }
+
+      it "writes cookies and redirects to dashboard" do
+        any_instance_of(Identity::LoginExternal) do |finalize|
+          mock(finalize).write_authentication_to_cookie(cookie_data)
+        end
+
+        get "/login/external?token=#{token}"
+
+        assert_equal 302, last_response.status
+        assert_equal Identity::Config.dashboard_url, last_response.headers["Location"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this case we introduce a Finalize endpoint that can receive a signed token and write cookies based on it. This will be used by Fido in federated identity workflow.