### PR TITLE
Bump gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       open4
     Platform (0.4.0)
     addressable (2.3.6)
-    backports (3.6.3)
+    backports (3.6.6)
     bourbon (4.0.2)
       sass (~> 3.3)
       thor
@@ -17,8 +17,7 @@ GEM
     coffee-script-source (1.8.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    eventmachine (1.0.4)
-    excon (0.44.1)
+    excon (0.45.4)
     execjs (2.2.2)
     fernet (1.5)
     hike (1.2.1)
@@ -34,16 +33,16 @@ GEM
       slop (~> 3.4)
     puma (1.6.3)
       rack (~> 1.2)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-flash3 (1.0.3)
       rack
     rack-instruments (0.3.2)
       slides (~> 0.2.0)
-    rack-protection (1.3.2)
+    rack-protection (1.5.3)
       rack
     rack-ssl (1.3.2)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rack_csrf (2.4.0)
       rack (>= 0.9)
@@ -53,19 +52,19 @@ GEM
     rr (1.0.4)
     safe_yaml (1.0.4)
     sass (3.4.7)
-    sinatra (1.3.3)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
-      tilt (~> 1.3, >= 1.3.3)
-    sinatra-contrib (1.3.2)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.6)
       backports (>= 2.0)
-      eventmachine
+      multi_json
       rack-protection
       rack-test
-      sinatra (~> 1.3.0)
-      tilt (~> 1.3)
-    sinatra-router (0.2.0)
-      sinatra (~> 1.3.3)
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    sinatra-router (0.2.3)
+      sinatra (~> 1.4)
     slides (0.2.0)
     slim (1.3.5)
       temple (~> 0.5.5)
@@ -81,7 +80,7 @@ GEM
       tilt (~> 1.1)
     temple (0.5.5)
     thor (0.19.1)
-    tilt (1.3.3)
+    tilt (1.3.7)
     timecop (0.3.5)
     webmock (1.18.0)
       addressable (>= 2.3.6)
@@ -124,4 +123,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   1.10.4
+   1.10.5


### PR DESCRIPTION
Hey folks,

I know bumping gems can be pretty stressful and costly, so feel free to ignore/close; just opening this in case it helps others develop Identity locally.

Part of the problem is related to [this Excon issue with Ruby 2.2.x](https://github.com/excon/excon/issues/482), which resulted in all API calls throwing an odd `Excon::Errors::SocketError` exception: break from proc-closure (LocalJumpError).

This error wasn't being handled well though, because of what seems to be an [incompatibility between earlier versions of Sinatra and Rack 1.6](https://github.com/sinatra/sinatra/issues/951): the error response generated by Sinatra was passed to Rack as a String, which didn't respond to `join`, which was causing all sorts of weird internal Rack errors.

So in order to get it to work here I had to bump both Excon and Sinatra.

And again, feel free to close for now/etc.