### PR TITLE
Support upstream sms-number changes.

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -203,12 +203,12 @@ module Identity
           request_ids: request_ids,
           user: @cookie.email,
           pass: @cookie.password,
-          version: "3.sms-number",
+          version: "3",
         }
 
         begin
           api = HerokuAPI.new(options)
-          res = api.post(path: "/account/sms-number/actions/recover",
+          res = api.post(path: "/users/~/sms-number/actions/recover",
             expects: 201)
         rescue Excon::Errors::UnprocessableEntity => e
           flash[:error] = decode_error(e.response.body)

--- a/lib/identity/helpers/api.rb
+++ b/lib/identity/helpers/api.rb
@@ -26,11 +26,11 @@ module Identity::Helpers
         request_ids: request_ids,
         user: @cookie.email,
         pass: @cookie.password,
-        version: "3.sms-number",
+        version: "3",
       }
 
       api = Identity::HerokuAPI.new(options)
-      res = api.get(path: "/account/sms-number",
+      res = api.get(path: "/users/~/sms-number",
           expects: 200)
       MultiJson.decode(res.body)["sms_number"]
     rescue

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -189,7 +189,7 @@ describe Identity::Account do
   describe "POST /account/two-factor/recovery/sms" do
     it "redirects back to two-factor if number missing" do
       stub_heroku_api do
-        post("/account/sms-number/actions/recover") {
+        post("/users/~/sms-number/actions/recover") {
           [422, MultiJson.encode({ message: "Number missing." })]
         }
       end

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -172,7 +172,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
     })
   end
 
-  get "/account/sms-number" do
+  get "/users/~/sms-number" do
     authorized!
 
     MultiJson.encode({
@@ -180,7 +180,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
     })
   end
 
-  post "/account/sms-number/actions/recover" do
+  post "/users/~/sms-number/actions/recover" do
     status(201)
   end
 end


### PR DESCRIPTION
This PR supports changes introduced in heroku/api#4722.

- `sms-number` API variant has gone away, with it's functionality moved into mainstream v3.
- `sms-number` endpoints have moved from `/account/sms-number` to `/users/~/sms-number`.