### PR TITLE
Tweak login page when user is coming from the authorization flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "yui-compressor"
 
 group :development, :test do
   #gem "debugger"
+  gem "capybara"
   gem "minitest"
   gem "rack-test"
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,12 @@ GEM
     bourbon (4.0.2)
       sass (~> 3.3)
       thor
+    capybara (2.5.0)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coderay (1.1.0)
     coffee-script (2.3.0)
       coffee-script-source
@@ -23,8 +29,12 @@ GEM
     hike (1.2.1)
     jwt (1.5.1)
     method_source (0.8.2)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
     minitest (5.4.3)
     multi_json (1.10.1)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     oj (2.0.0)
     open4 (1.3.0)
     pry (0.10.1)
@@ -85,6 +95,8 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
     yui-compressor (0.9.6)
       POpen4 (>= 0.1.4)
 
@@ -94,6 +106,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   bourbon
+  capybara
   coffee-script
   excon
   fernet
@@ -123,4 +136,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/assets/stylesheets/purple/_purple-ui.scss
+++ b/assets/stylesheets/purple/_purple-ui.scss
@@ -3385,13 +3385,11 @@ a.thumbnail:hover, a.thumbnail:focus, a.thumbnail.active {
     color: #24c2fb; }
 
 .alert-warning {
-  background-color: #fef8f2;
-  border-color: #fbe4cf;
-  color: #F4B170; }
+  background-color: rgba(230,123,66,0.1);
+  border-color: rgba(230,123,66,0.2);
+  color: #e36b2b; }
   .alert-warning hr {
     border-top-color: #f9d7b7; }
-  .alert-warning .alert-link {
-    color: #f09641; }
 
 .alert-danger {
   background-color: #D64242;

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -269,7 +269,11 @@ module Identity
     # Redirects to the signup app adding a special param
     def redirect_to_signup_app(next_path)
       current_params = CGI.parse(URI.parse(request.fullpath).query.to_s)
-      next_params = URI.encode_www_form(current_params.merge({from: 'id'}))
+      append_params  = { from: 'id' }
+      if @cookie.authorize_params
+        append_params["redirect-url"] = "#{request.base_url}/oauth/authorize"
+      end
+      next_params = URI.encode_www_form(current_params.merge(append_params))
       redirect to("#{Config.signup_url}#{next_path}?#{next_params}")
     end
   end

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -270,8 +270,8 @@ module Identity
     def redirect_to_signup_app(next_path)
       current_params = CGI.parse(URI.parse(request.fullpath).query.to_s)
       append_params  = { from: 'id' }
-      if @cookie.authorize_params
-        append_params["redirect-url"] = "#{request.base_url}/oauth/authorize"
+      if redirect_url = @cookie.post_signup_url
+        append_params["redirect-url"] = redirect_url
       end
       next_params = URI.encode_www_form(current_params.merge(append_params))
       redirect to("#{Config.signup_url}#{next_path}?#{next_params}")

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -253,6 +253,7 @@ module Identity
       # user is not logged in
       rescue Identity::Errors::NoSession
         flash[:link_account] = true
+        @cookie.post_signup_url = request.url
         @cookie.authorize_params = authorize_params
         redirect to("/login")
       # refresh token dance was unsuccessful

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -19,6 +19,9 @@ module Identity
 
     namespace "/login" do
       get do
+        if flash[:link_account] && @cookie.authorize_params
+          @oauth_client = get_client_info(@cookie.authorize_params["client_id"])
+        end
         slim :login, layout: :"layouts/purple"
       end
 
@@ -293,6 +296,14 @@ module Identity
         # if it's not is basic auth, hopefully it's in the request body
         params[:client_secret]
       end
+    end
+
+    def get_client_info(client_id)
+      api = HerokuAPI.new(ip: request.ip, version: 3)
+      res = api.get(
+        expects: 200,
+        path: "/oauth/clients/#{client_id}")
+      MultiJson.decode(res.body)
     end
 
     def logout

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -244,8 +244,13 @@ module Identity
       # destroyed or expired, redirect to login
       rescue Excon::Errors::NotFound
         redirect to("/login")
+      # user is not logged in
+      rescue Identity::Errors::NoSession
+        flash[:link_account] = true
+        @cookie.authorize_params = authorize_params
+        redirect to("/login")
       # refresh token dance was unsuccessful
-      rescue Excon::Errors::Unauthorized, Identity::Errors::NoSession
+      rescue Excon::Errors::Unauthorized
         @cookie.authorize_params = authorize_params
         redirect to("/login")
       rescue Identity::Errors::PasswordExpired => e

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -19,8 +19,11 @@ module Identity
 
     namespace "/login" do
       get do
+        @campaign = "login" # used to identify the user if they signup from here
         if flash[:link_account] && @cookie.authorize_params
-          @oauth_client = get_client_info(@cookie.authorize_params["client_id"])
+          client_id = @cookie.authorize_params["client_id"]
+          @oauth_client = get_client_info(client_id)
+          @campaign     = get_client_campaign(client_id)
         end
         slim :login, layout: :"layouts/purple"
       end
@@ -304,6 +307,15 @@ module Identity
         expects: 200,
         path: "/oauth/clients/#{client_id}")
       MultiJson.decode(res.body)
+    end
+
+    # hardcoded for now :{ we can potentially move this to API at some point,
+    # but will need some sort of service to issue salesforce campaign ids
+    def get_client_campaign(oauth_client_id)
+      {
+        "e780a170-f68f-46d2-99fd-a9878d8e6c75" => "parse",
+        "14cf504a-0d20-4460-a2ac-9547365ddf8a" => "parse",
+      }[oauth_client_id] || "login"
     end
 
     def logout

--- a/lib/identity/cookie.rb
+++ b/lib/identity/cookie.rb
@@ -33,6 +33,14 @@ module Identity
       @session["authorize_params"] = params ? MultiJson.encode(params) : nil
     end
 
+    def post_signup_url
+      @session["post_signup_url"]
+    end
+
+    def post_signup_url=(url)
+      @session["post_signup_url"] = url
+    end
+
     def clear
       @session.clear
     end

--- a/lib/identity/design.rb
+++ b/lib/identity/design.rb
@@ -17,6 +17,10 @@ module Identity
 
     namespace "/design" do
       get "/login" do
+        if params[:client]
+          flash.now[:link_account] = true
+          @oauth_client = { "name" => params[:client] }
+        end
         slim :"login", layout: @layout
       end
 

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -159,7 +159,24 @@ describe Identity::Account do
     it "redirects to the same slug in the signup app" do
       get "/signup/foo"
       assert_equal 302, last_response.status
-      assert_equal "#{Identity::Config.signup_url}/foo?from=id", last_response.headers["Location"]
+      assert_equal "#{Identity::Config.signup_url}/foo?from=id",
+        last_response.headers["Location"]
+    end
+
+    it "sets the redirect-url so the user is taken back when authorizing a client" do
+      rack_env = {
+        # set a cookie
+        "rack.session" => { "authorize_params" => "{}" }
+      }
+      get "/signup/foo", {}, rack_env
+      expected_params = {
+        "from" => "id",
+        "redirect-url" => "http://example.org/oauth/authorize"
+      }
+      encoded_params = URI.encode_www_form(expected_params)
+      assert_equal 302, last_response.status
+      assert_equal "#{Identity::Config.signup_url}/foo?#{encoded_params}",
+        last_response.headers["Location"]
     end
   end
 

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -164,14 +164,15 @@ describe Identity::Account do
     end
 
     it "sets the redirect-url so the user is taken back when authorizing a client" do
+      url = "https://id.heroku.com/oauth/authorize/1234"
       rack_env = {
         # set a cookie
-        "rack.session" => { "authorize_params" => "{}" }
+        "rack.session" => { "post_signup_url" => url }
       }
       get "/signup/foo", {}, rack_env
       expected_params = {
         "from" => "id",
-        "redirect-url" => "http://example.org/oauth/authorize"
+        "redirect-url" => url
       }
       encoded_params = URI.encode_www_form(expected_params)
       assert_equal 302, last_response.status

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -328,6 +328,42 @@ describe Identity::Auth do
       get "/login"
       assert_equal 200, last_response.status
     end
+
+    describe "when coming from a pending authorization" do
+      before do
+        @authorize_params = { client_id: SecureRandom.uuid }
+      end
+
+      let(:rack_env) do
+        {
+          "x-rack.flash" => { link_account: true },
+          "rack.session" => { "authorize_params" => MultiJson.encode(@authorize_params) }
+        }
+      end
+
+      # use Capybara's for matchers like has_content? and has_elector?
+      let(:page) { Capybara::Node::Simple.new(last_response.body) }
+
+      it "renders a slightly different login screen" do
+        get "/login", {}, rack_env
+        assert_equal 200, last_response.status
+        assert page.has_selector?("h3", text: "Link accounts")
+      end
+
+      it "uses the default sign up campaign 'login'" do
+        get "/login", {}, rack_env
+        assert_equal 200, last_response.status
+        assert page.has_link?("sign up", href: "/signup/login")
+      end
+
+      it "uses a custom sign-up campaign for Parse" do
+        # parse's client id is hardcoded for now:
+        @authorize_params[:client_id] = "e780a170-f68f-46d2-99fd-a9878d8e6c75"
+        get "/login", {}, rack_env
+        assert_equal 200, last_response.status
+        assert page.has_link?("sign up", href: "/signup/parse")
+      end
+    end
   end
 
   describe "POST /login" do

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -347,7 +347,7 @@ describe Identity::Auth do
       it "renders a slightly different login screen" do
         get "/login", {}, rack_env
         assert_equal 200, last_response.status
-        assert page.has_selector?("h3", text: "Link accounts")
+        assert page.has_selector?("h3", text: "Log in to link accounts")
       end
 
       it "uses the default sign up campaign 'login'" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ ENV["SIGNUP_URL"]            = "https://signup.heroku.com"
 require "bundler/setup"
 Bundler.require(:default, :test)
 
+require "capybara"
 require "minitest/autorun"
 require "minitest/spec"
 require "rack/test"

--- a/views/login.slim
+++ b/views/login.slim
@@ -9,10 +9,10 @@
     == render :slim, :"_flash", layout: false
     - if flash[:link_account]
       div.alert.alert-warning
-        ' #{@oauth_client["name"]} is requesting access to your account.
-        ' Please log in or 
+        ' #{@oauth_client["name"]} is requesting scoped access to your account.
+        ' Log in or 
         a href="/signup/#{@campaign}" sign up 
-        ' to review their request.
+        ' to review the request.
     input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
     .form-group
       label for="email" Email address

--- a/views/login.slim
+++ b/views/login.slim
@@ -2,7 +2,7 @@
 
 #login.panel
   - if flash[:link_account]
-    h3 Link accounts
+    h3 Link accounts and log in
   - else
     h3 Log in to your account
   form role="form" method="post" action="/login"

--- a/views/login.slim
+++ b/views/login.slim
@@ -1,9 +1,17 @@
 - @title = "Login"
 
 #login.panel
-  h3 Log in to your account
+  - if flash[:link_account]
+    h3 Link accounts
+  - else
+    h3 Log in to your account
   form role="form" method="post" action="/login"
     == render :slim, :"_flash", layout: false
+    - if flash[:link_account]
+      div.alert.alert-warning
+        ' Please log in or
+        a href="/signup/login" create an account 
+        ' to authorize this service.
     input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
     .form-group
       label for="email" Email address

--- a/views/login.slim
+++ b/views/login.slim
@@ -10,8 +10,8 @@
     - if flash[:link_account]
       div.alert.alert-warning
         ' Please log in or
-        a href="/signup/login" create an account 
-        ' to authorize this service.
+        a href="/signup/login" sign up 
+        ' to link your Heroku account with #{@oauth_client["name"]}
     input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
     .form-group
       label for="email" Email address

--- a/views/login.slim
+++ b/views/login.slim
@@ -10,7 +10,7 @@
     - if flash[:link_account]
       div.alert.alert-warning
         ' Please log in or
-        a href="/signup/login" sign up 
+        a href="/signup/#{@campaign}" sign up 
         ' to link your Heroku account with #{@oauth_client["name"]}
     input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
     .form-group
@@ -23,7 +23,7 @@
       input#password.form-control.password type="password" name="password" autocomplete="off" placeholder="Password" tabindex="2"
     button.btn.btn-primary.btn-lg.btn-block type="submit" name="commit" value="Log In" tabindex="3" Log In
 
-  a.panel-footer href="/signup/login"
+  a.panel-footer href="/signup/#{@campaign}"
     | New to Heroku? &nbsp;
     span Sign Up
 

--- a/views/login.slim
+++ b/views/login.slim
@@ -2,16 +2,17 @@
 
 #login.panel
   - if flash[:link_account]
-    h3 Link accounts and log in
+    h3 Log in to link accounts
   - else
     h3 Log in to your account
   form role="form" method="post" action="/login"
     == render :slim, :"_flash", layout: false
     - if flash[:link_account]
       div.alert.alert-warning
-        ' Please log in or
+        ' #{@oauth_client["name"]} is requesting access to your account.
+        ' Please log in or 
         a href="/signup/#{@campaign}" sign up 
-        ' to link your Heroku account with #{@oauth_client["name"]}
+        ' to review their request.
     input type="hidden" name=Rack::Csrf.field value=Rack::Csrf.token(env)
     .form-group
       label for="email" Email address


### PR DESCRIPTION
WIP, looks like this:

![screen shot 2015-08-24 at 4 32 46 pm](https://cloud.githubusercontent.com/assets/2248/9455249/e8914000-4a7d-11e5-9b4f-5afc8c466923.png)

I'll see if I can get heroku/api#4740 in to make this message more specific with the registered client name. Don't merge for now.