### PR TITLE
Rescue 403 from API when resetting password

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -176,17 +176,18 @@ module Identity
         begin
           api = HerokuAPI.new(ip: request.ip, request_ids: request_ids,
             version: 2)
-          res = api.post(path: "/auth/finish_reset_password/#{token}",
-            expects: 200, body: URI.encode_www_form({
-              :password              => params[:password],
-              :password_confirmation => params[:password_confirmation],
-            }))
+          body = URI.encode_www_form({
+            :password              => params[:password],
+            :password_confirmation => params[:password_confirmation],
+          })
+          api.post(path: "/auth/finish_reset_password/#{token}",
+                   expects: 200, body: body)
 
           flash[:success] = "Your password has been changed."
           redirect to("/login")
         rescue Excon::Errors::NotFound => e
           slim :"account/password/not_found", layout: :"layouts/purple"
-        rescue Excon::Errors::UnprocessableEntity => e
+        rescue Excon::Errors::Forbidden, Excon::Errors::UnprocessableEntity => e
           flash[:error] = decode_error(e.response.body)
           redirect to("/account/password/reset/#{token}")
         end

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -145,6 +145,20 @@ describe Identity::Account do
       assert_equal 302, last_response.status
       assert_match %r{/login$}, last_response.headers["Location"]
     end
+
+    [ 403, 422 ].each do |error_code|
+      it "redirects back to reset page when there's a #{error_code} error" do
+        stub_heroku_api do
+          post("/auth/finish_reset_password/c45685917ef644198a0fececa10d479a") {
+            [ error_code, MultiJson.encode({ message: "a #{error_code} error" }) ]
+          }
+        end
+        post "/account/password/reset/c45685917ef644198a0fececa10d479a",
+          password: "1234567890ab", password_confirmation: "1234567890ab"
+        assert_equal 302, last_response.status
+        assert_match %r{/account/password/reset/c45685917ef644198a0fececa10d479a$}, last_response.headers["Location"]
+      end
+    end
   end
 
   describe "GET /signup" do


### PR DESCRIPTION
This is to fix resetting password getting 500 for Herokai: https://rollbar.com/Heroku-3/identity/items/36/