### PR TITLE
Handle 422 responses from POST /oauth/tokens to API

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -203,6 +203,10 @@ module Identity
           # pass the whole API error through to the client
           content_type(:json)
           [401, e.response.body]
+        rescue Excon::Errors::UnprocessableEntity => e
+          # ditto
+          content_type(:json)
+          [422, e.response.body]
         end
       end
     end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -321,6 +321,19 @@ describe Identity::Auth do
       post "/oauth/token"
       assert_equal 401, last_response.status
     end
+
+    it "forwards a 422" do
+      stub_heroku_api do
+        post("/oauth/tokens") {
+          raise Excon::Errors::UnprocessableEntity.new("missing param", nil,
+            Excon::Response.new(body: "missing param"))
+        }
+      end
+      post "/login", email: "kerry@heroku.com", password: "abcdefgh"
+      post "/oauth/authorize", client_id: "dashboard"
+      post "/oauth/token"
+      assert_equal 422, last_response.status
+    end
   end
 
   describe "GET /login" do


### PR DESCRIPTION
At least some of the responses we've been seeing lately are from missing refresh tokens, so it might be Federated Identity-related.

https://rollbar.com/Heroku-3/identity/items/37/

/cc @heroku/enterprise-experience-team 

Ready for review @heroku/api 