### PR TITLE
Only render "link account" dialogue for untrusted clients

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -20,10 +20,14 @@ module Identity
     namespace "/login" do
       get do
         @campaign = "login" # used to identify the user if they signup from here
-        if flash[:link_account] && @cookie.authorize_params
+        @link_account = flash[:link_account] && @cookie.authorize_params
+        if @link_account
           client_id = @cookie.authorize_params["client_id"]
           @oauth_client = get_client_info(client_id)
           @campaign     = get_client_campaign(client_id)
+          if @oauth_client["trusted"]
+            @link_account = false
+          end
         end
         slim :login, layout: :"layouts/purple"
       end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -357,24 +357,29 @@ describe Identity::Auth do
       # use Capybara's for matchers like has_content? and has_elector?
       let(:page) { Capybara::Node::Simple.new(last_response.body) }
 
-      it "renders a slightly different login screen" do
+      it "renders the regular login page for trusted clients" do
         get "/login", {}, rack_env
         assert_equal 200, last_response.status
-        assert page.has_selector?("h3", text: "Log in to link accounts")
+        assert page.has_selector?("h3", text: "Log in to your account")
       end
 
-      it "uses the default sign up campaign 'login'" do
-        get "/login", {}, rack_env
-        assert_equal 200, last_response.status
-        assert page.has_link?("sign up", href: "/signup/login")
-      end
+      describe "for untrusted clients" do
+        before do
+          # parse's client id is hardcoded for now:
+          @authorize_params[:client_id] = "e780a170-f68f-46d2-99fd-a9878d8e6c75"
+        end
 
-      it "uses a custom sign-up campaign for Parse" do
-        # parse's client id is hardcoded for now:
-        @authorize_params[:client_id] = "e780a170-f68f-46d2-99fd-a9878d8e6c75"
-        get "/login", {}, rack_env
-        assert_equal 200, last_response.status
-        assert page.has_link?("sign up", href: "/signup/parse")
+        it "renders a slightly different login screen for untrusted" do
+          get "/login", {}, rack_env
+          assert_equal 200, last_response.status
+          assert page.has_selector?("h3", text: "Log in to link accounts")
+        end
+
+        it "uses a custom sign-up campaign for Parse" do
+          get "/login", {}, rack_env
+          assert_equal 200, last_response.status
+          assert page.has_link?("sign up", href: "/signup/parse")
+        end
       end
     end
   end

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -118,6 +118,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
   end
 
   get "/oauth/clients/:id" do |id|
+    parse_oauth_client = "e780a170-f68f-46d2-99fd-a9878d8e6c75"
     status(200)
     MultiJson.encode({
       id:                 id,
@@ -125,7 +126,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
       description:        "This is a sample OAuth client rendered by the API stub.",
       ignores_delinquent: false,
       redirect_uri:       "https://example.com/oauth/callback/heroku",
-      trusted:            true,
+      trusted:            id != parse_oauth_client,
     })
   end
 

--- a/views/login.slim
+++ b/views/login.slim
@@ -1,13 +1,13 @@
 - @title = "Login"
 
 #login.panel
-  - if flash[:link_account]
+  - if @link_account
     h3 Log in to link accounts
   - else
     h3 Log in to your account
   form role="form" method="post" action="/login"
     == render :slim, :"_flash", layout: false
-    - if flash[:link_account]
+    - if @link_account
       div.alert.alert-warning
         ' #{@oauth_client["name"]} is requesting scoped access to your account.
         ' Log in or 


### PR DESCRIPTION
for trusted clients keep previous behavior (always render standard
login screen)