### PR TITLE
Generically handle 4xx responses from API's POST /oauth/tokens

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -209,14 +209,11 @@ module Identity
           #raise "missing=session_nonce" unless response[:session_nonce]
 
           MultiJson.encode(response)
-        rescue Excon::Errors::Unauthorized => e
+        # Handle 4xx errors from API
+        rescue Excon::Errors::ClientError => e
           # pass the whole API error through to the client
           content_type(:json)
-          [401, e.response.body]
-        rescue Excon::Errors::UnprocessableEntity => e
-          # ditto
-          content_type(:json)
-          [422, e.response.body]
+          [e.response.status, e.response.body]
         end
       end
     end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -313,11 +313,9 @@ describe Identity::Auth do
       stub_heroku_api do
         post("/oauth/tokens") {
           raise Excon::Errors::Unauthorized.new("Unauthorized", nil,
-            Excon::Response.new(body: "Unauthorized"))
+            Excon::Response.new(body: "Unauthorized", status: 401))
         }
       end
-      post "/login", email: "kerry@heroku.com", password: "abcdefgh"
-      post "/oauth/authorize", client_id: "dashboard"
       post "/oauth/token"
       assert_equal 401, last_response.status
     end
@@ -326,11 +324,9 @@ describe Identity::Auth do
       stub_heroku_api do
         post("/oauth/tokens") {
           raise Excon::Errors::UnprocessableEntity.new("missing param", nil,
-            Excon::Response.new(body: "missing param"))
+            Excon::Response.new(body: "missing param", status: 422))
         }
       end
-      post "/login", email: "kerry@heroku.com", password: "abcdefgh"
-      post "/oauth/authorize", client_id: "dashboard"
       post "/oauth/token"
       assert_equal 422, last_response.status
     end


### PR DESCRIPTION
Seeing someone probe identity's /token endpoint with malformed request to see if they can get something interesting back. API is responding appropriately with 400, but Identity doesn't know what to do and throws a 500.
https://rollbar.com/Heroku-3/identity/items/42

This PR makes Identity forward any 4xx response from API to the user for POST /token requests.

Ready for review @heroku/api 
