### PR TITLE
Support `prompt=login` on /oauth/authorize

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -108,7 +108,7 @@ module Identity
       get "/email/confirm/:token" do |token|
         begin
           # confirming an e-mail change requires authentication
-          raise Identity::Errors::NoSession if !@cookie.access_token
+          raise Identity::Errors::LoginRequired if !@cookie.access_token
           api = HerokuAPI.new(user: nil, pass: @cookie.access_token,
             ip: request.ip, request_ids: request_ids, version: 2)
           # currently returns a 302, but will return a 200
@@ -130,7 +130,7 @@ module Identity
           rescue Excon::Errors::Unauthorized
             redirect to("/logout")
           end
-        rescue Identity::Errors::NoSession
+        rescue Identity::Errors::LoginRequired
           @cookie.redirect_url = request.env["PATH_INFO"]
           redirect to("/login")
         end

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -1,5 +1,5 @@
 module Identity::Errors
-  class NoSession < StandardError
+  class LoginRequired < StandardError
   end
 
   class PasswordExpired < StandardError

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -80,6 +80,14 @@ describe Identity::Auth do
       assert_match /you are suspended/, last_response.body
     end
 
+    it "redirects to login when prompt=login is provided" do
+      post "/login", email: "kerry@heroku.com", password: "abcdefgh"
+
+      post "/oauth/authorize", client_id: "dashboard", state: "my-state", prompt: "login"
+      assert_equal 302, last_response.status
+      assert_equal "http://example.org/login", last_response.headers["Location"]
+    end
+
     it "redirects to password reset when a user's password has expired" do
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"
 


### PR DESCRIPTION
For users that are already authenticated in identity, /oauth/authorize will always return a code for the currently logged in identity user. I'm working on a scenario (heroku/dashboard-v6#2213) where we'd want to allow users to login to other accounts without completely logging out of identity.

OpenId Connect supports use of a `prompt` parameter [here](http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint). When that parameter is `login`, the user is always prompted for credentials. I know we're not implementing connect, but this seemed like a reasonable and idiomatic solution.

So, with this PR, client apps can add `prompt=login` to the authorize request, which will force an email/password prompt.

