### PR TITLE
Show reset errors

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -166,7 +166,8 @@ module Identity
             expects: 200)
           @user = MultiJson.decode(res.body)
 
-          # persist the user in the flash in case we need to render an error from the post
+          # Persist the user in the flash in case we need to render an error
+          # from the post.
           flash[:user] = @user
 
           slim :"account/password/finish_reset", layout: :"layouts/purple"
@@ -192,8 +193,8 @@ module Identity
           slim :"account/password/not_found", layout: :"layouts/purple"
         rescue Excon::Errors::Forbidden, Excon::Errors::UnprocessableEntity => e
           Identity.log(password_reset_error: true,
-                        error_body: e.response.body,
-                        error_code: e.response.status)
+                       error_body: e.response.body,
+                       error_code: e.response.status)
 
           @user = flash[:user]
           flash[:error] = decode_error(e.response.body)

--- a/lib/identity/helpers/api.rb
+++ b/lib/identity/helpers/api.rb
@@ -5,12 +5,17 @@ module Identity::Helpers
       #   1. { "id":..., "message":... } (V3)
       #   2. { "error":... } (V2)
       #   3. [["password","is too short (minimum is 6 characters)"]] (V-Insane)
-      #   4. "User not found." (V2 404)
+      #   4. {"password":["is too short (minimum is 15 characters for Herokai)"]}
+      #   5. "User not found." (V2 404)
+
       begin
         json = MultiJson.decode(body)
-        !json.is_a?(Array) ?
-          json["error"] || json["message"] :
-          json.map { |e| e.join(" ") }.join("; ")
+
+        unless json.is_a?(Array)
+          if json.has_key?("error") || json.has_key?("message") || json.has_key?("password")
+            json.map { |e| e.join(" ") }.join("; ")
+          end
+        end
       rescue MultiJson::DecodeError => e
         # V2 logs some special cases, like 404s, as plain text
         log :decode_error, body: body

--- a/lib/identity/helpers/api.rb
+++ b/lib/identity/helpers/api.rb
@@ -12,7 +12,9 @@ module Identity::Helpers
         json = MultiJson.decode(body)
 
         unless json.is_a?(Array)
-          if json.has_key?("error") || json.has_key?("message") || json.has_key?("password")
+          if json.has_key?("error") ||
+              json.has_key?("message") ||
+              json.has_key?("password")
             json.map { |e| e.join(" ") }.join("; ")
           end
         end

--- a/lib/identity/helpers/api.rb
+++ b/lib/identity/helpers/api.rb
@@ -12,7 +12,7 @@ module Identity::Helpers
         json = MultiJson.decode(body)
 
         unless json.is_a?(Array)
-          if json.has_key?("error") ||
+          if json.has_key?("error")    ||
               json.has_key?("message") ||
               json.has_key?("password")
             json.map { |e| e.join(" ") }.join("; ")

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -157,7 +157,8 @@ describe Identity::Account do
           password: "1234567890ab", password_confirmation: "1234567890ab"
         assert_equal 302, last_response.status
         assert_match %r{/account/password/reset/c45685917ef644198a0fececa10d479a$}, last_response.headers["Location"]
-        assert_contains "a #{error_code} error", last_response.body
+        follow_redirect!
+        assert_match /a #{error_code} error/, last_response.body
       end
     end
   end

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -157,6 +157,7 @@ describe Identity::Account do
           password: "1234567890ab", password_confirmation: "1234567890ab"
         assert_equal 302, last_response.status
         assert_match %r{/account/password/reset/c45685917ef644198a0fececa10d479a$}, last_response.headers["Location"]
+        assert_contains "a #{error_code} error", last_response.body
       end
     end
   end


### PR DESCRIPTION
This should allow users to see why their password resets are not working. Triggred by this support ticket: https://support.heroku.com/tickets/283025.

I'm not able to get the test to pass and I'm not sure why. I could use another set of eyes on this.

@paulelliott I discovered that the flash is actually persistent so we don't have to change the redirect behavior. I'm also using the flash to persist the user info in the case where there is an error. By persisting it in the flash it reduces the number of api calls we have to make.