### PR TITLE
Handle suspended account errors on /oauth/token

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -217,6 +217,9 @@ module Identity
           # pass the whole API error through to the client
           content_type(:json)
           [e.response.status, e.response.body]
+        rescue Identity::Errors::SuspendedAccount => e
+          content_type(:json)
+          [403, e.message]
         end
       end
     end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -341,11 +341,13 @@ describe Identity::Auth do
 
     it "forwards a 403" do
       stub_heroku_api do
-        post("/oauth/tokens") {
-          raise Excon::Errors::Forbidden.new("suspended", nil,
-            Excon::Response.new(body:
-              MultiJson.encode({id:"suspended", message:"ruh roh"}), status: 403))
-        }
+        post("/oauth/tokens") do
+          body = MultiJson.encode(id: "suspended", message: "ruh roh")
+          raise Excon::Errors::Forbidden.new(
+            "suspended",
+            nil,
+            Excon::Response.new(body: body, status: 403))
+        end
       end
       post "/oauth/token"
       assert_equal 403, last_response.status

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -338,6 +338,19 @@ describe Identity::Auth do
       post "/oauth/token"
       assert_equal 422, last_response.status
     end
+
+    it "forwards a 403" do
+      stub_heroku_api do
+        post("/oauth/tokens") {
+          raise Excon::Errors::Forbidden.new("suspended", nil,
+            Excon::Response.new(body:
+              MultiJson.encode({id:"suspended", message:"ruh roh"}), status: 403))
+        }
+      end
+      post "/oauth/token"
+      assert_equal 403, last_response.status
+      assert_equal "ruh roh", last_response.body
+    end
   end
 
   describe "GET /login" do


### PR DESCRIPTION
Since we're wrapping suspended account requests, we've been throwing 500s for those responses from API.

@heroku/api ready for review