### PR TITLE
Remove the GET /account endpoint

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -21,28 +21,6 @@ module Identity
     end
 
     namespace "/account" do
-      # The omniauth strategy used to make a call to /account after a
-      # successful authentication, so proxy this through to core.
-      # Authentication occurs via a header with a bearer token.
-      #
-      # Remove this as soon as we get Devcenter and Dashboard upgraded.
-      get do
-        return 401 if !request.env["HTTP_AUTHORIZATION"]
-        api = HerokuAPI.new(user: nil, request_ids: request_ids, version: 2,
-          authorization: request.env["HTTP_AUTHORIZATION"],
-            ip: request.ip,
-          # not necessarily V3, respond with whatever the client asks for
-          headers: {
-            "Accept" => request.env["HTTP_ACCEPT"] || "application/json"
-          })
-        begin
-          res = api.get(path: "/account", expects: 200)
-          content_type(:json)
-          res.body
-        rescue Excon::Errors::Unauthorized
-          return 401
-        end
-      end
 
       get "/accept/:id/:token" do |id, token|
         redirect_to_signup_app(request.path)

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -16,36 +16,6 @@ describe Identity::Account do
     rack_mock_session.clear_cookies
   end
 
-  describe "GET /account" do
-    it "responds with 401 without a session" do
-      get "/account"
-      assert_equal 401, last_response.status
-    end
-
-    it "responds with a 401 with an invalid session" do
-      stub_heroku_api do
-        get "/account" do
-          halt 401
-        end
-      end
-      authorize "", "secret"
-      get "/account"
-      assert_equal 401, last_response.status
-    end
-
-    it "proxies to the API" do
-      stub_heroku_api do
-        get "/account" do
-          "{}"
-        end
-      end
-      authorize "", "secret"
-      get "/account"
-      assert_equal 200, last_response.status
-      assert_equal "{}", last_response.body
-    end
-  end
-
   describe "GET /account/accept/:id/:token" do
     it "redirects to the same path in the signup app" do
       stub(Identity::Config).redirect_all_signups { true }


### PR DESCRIPTION
Was originally used by an older version of Omniauth-Heroku that has been deprecated.
Internal properties are now using upgraded versions so we can remove this endpoint.

Another step toward getting Identity off of API v2.

Ready for review @heroku/api