### PR TITLE
Use API's v3 Invitations Endpoint

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -36,14 +36,16 @@ module Identity
       # to verify and log the user in.
       post "/accept/ok" do
         begin
-          api = HerokuAPI.new(ip: request.ip, request_ids: request_ids,
-            version: 3)
+          api = HerokuAPI.new(
+            ip:          request.ip,
+            request_ids: request_ids,
+            version:     3)
           res = api.patch(path: "/invitations/#{params[:token]}", expects: 200,
-            body: MultiJson.encode({
+            body: MultiJson.encode(
               password:              params[:password],
               password_confirmation: params[:password_confirmation],
               receive_newsletter:    params[:receive_newsletter]
-            }))
+            ))
           json = MultiJson.decode(res.body)
 
           # log the user in right away

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -37,14 +37,12 @@ module Identity
       post "/accept/ok" do
         begin
           api = HerokuAPI.new(ip: request.ip, request_ids: request_ids,
-            version: 2)
-          res = api.post(path: "/invitation2/save", expects: 200,
-            body: URI.encode_www_form({
-              "id"                          => params[:id],
-              "token"                       => params[:token],
-              "user[password]"              => params[:password],
-              "user[password_confirmation]" => params[:password_confirmation],
-              "user[receive_newsletter]"    => params[:receive_newsletter],
+            version: 3)
+          res = api.patch(path: "/invitations/#{params[:token]}", expects: 200,
+            body: MultiJson.encode({
+              password:              params[:password],
+              password_confirmation: params[:password_confirmation],
+              receive_newsletter:    params[:receive_newsletter]
             }))
           json = MultiJson.decode(res.body)
 

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -40,8 +40,10 @@ module Identity
             ip:          request.ip,
             request_ids: request_ids,
             version:     3)
-          res = api.patch(path: "/invitations/#{params[:token]}", expects: 200,
-            body: MultiJson.encode(
+          res = api.patch(
+            path:    "/invitations/#{params[:token]}",
+            expects: 200,
+            body:    MultiJson.encode(
               password:              params[:password],
               password_confirmation: params[:password_confirmation],
               receive_newsletter:    params[:receive_newsletter]

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -47,7 +47,7 @@ module Identity
           json = MultiJson.decode(res.body)
 
           # log the user in right away
-          perform_oauth_dance(json["email"], params[:password], nil)
+          perform_oauth_dance(json["user"]["email"], params[:password], nil)
 
           @redirect_uri = if @cookie.authorize_params
             # if we know that we're in the middle of an authorization attempt,

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -28,7 +28,7 @@ describe Identity::Account do
   describe "POST /account/accept/ok" do
     it "redirects to the signup app on success" do
       stub(Identity::Config).redirect_all_signups { true }
-      post "/account/accept/ok", token: 'foo'
+      post "/account/accept/ok", token: "foo"
       assert_equal 302, last_response.status
       assert_equal "#{Identity::Config.signup_url}/account/accept/ok?from=id", last_response.headers["Location"]
     end
@@ -39,7 +39,7 @@ describe Identity::Account do
           halt(404, "Not found")
         end
       end
-      post "/account/accept/ok", token: 'foo'
+      post "/account/accept/ok", token: "foo"
       assert_equal 302, last_response.status
       assert_match %r{/login$}, last_response.headers["Location"]
     end
@@ -47,12 +47,13 @@ describe Identity::Account do
     it "redirects to accept if the invitation data is wrong" do
       stub_heroku_api do
         patch "/invitations/:token" do
-          [422, MultiJson.encode({ message: "Password too short." })]
+          [422, MultiJson.encode(message: "Password too short.")]
         end
       end
-      post "/account/accept/ok", token: 'foo', password: 'yay', id: 123
+      post "/account/accept/ok", token: "foo", password: "yay", id: 123
       assert_equal 302, last_response.status
-      assert_match %r{/account/accept/123/foo$}, last_response.headers["Location"]
+      assert_match(
+        %r{/account/accept/123/foo$}, last_response.headers["Location"])
     end
   end
 

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -26,11 +26,33 @@ describe Identity::Account do
   end
 
   describe "POST /account/accept/ok" do
-    it "redirects to the signup app" do
+    it "redirects to the signup app on success" do
       stub(Identity::Config).redirect_all_signups { true }
-      post "/account/accept/ok"
+      post "/account/accept/ok", token: 'foo'
       assert_equal 302, last_response.status
       assert_equal "#{Identity::Config.signup_url}/account/accept/ok?from=id", last_response.headers["Location"]
+    end
+
+    it "redirects to login if the token is not found" do
+      stub_heroku_api do
+        patch "/invitations/:token" do
+          halt(404, "Not found")
+        end
+      end
+      post "/account/accept/ok", token: 'foo'
+      assert_equal 302, last_response.status
+      assert_match %r{/login$}, last_response.headers["Location"]
+    end
+
+    it "redirects to accept if the invitation data is wrong" do
+      stub_heroku_api do
+        patch "/invitations/:token" do
+          [422, MultiJson.encode({ message: "Password too short." })]
+        end
+      end
+      post "/account/accept/ok", token: 'foo', password: 'yay', id: 123
+      assert_equal 302, last_response.status
+      assert_match %r{/account/accept/123/foo$}, last_response.headers["Location"]
     end
   end
 

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -164,7 +164,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
     })
   end
 
-  post "/invitation2/save" do
+  patch "/invitations/:token" do
     MultiJson.encode({
       email: "kerry@heroku.com",
       signup_source: {

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -166,9 +166,10 @@ If you don't receive an email, and it's not in your spam folder, this could mean
 
   patch "/invitations/:token" do
     MultiJson.encode({
-      email: "kerry@heroku.com",
-      signup_source: {
-        redirect_uri: "https://dashboard.heroku.com"
+      created_at: Time.now,
+      user: {
+        email: "kerry@heroku.com",
+        id:    "06dcaabe-f7cd-473a-aa10-df54045ff69c"
       }
     })
   end

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -166,7 +166,7 @@ If you don't receive an email, and it's not in your spam folder, this could mean
 
   patch "/invitations/:token" do
     MultiJson.encode({
-      created_at: Time.now,
+      created_at: Time.now.utc,
       user: {
         email: "kerry@heroku.com",
         id:    "06dcaabe-f7cd-473a-aa10-df54045ff69c"


### PR DESCRIPTION
For `POST /account/accept/ok`, use API's new v3 endpoint.