### PR TITLE
Improve auth flows with SSO

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -231,6 +231,8 @@ module Identity
       elsif !@cookie.access_token || params[:prompt] == "login"
         # Have users login if they don't have a session, or the client
         # has requested an explicit login
+        flash[:link_account] = true
+        @cookie.post_signup_url = request.url
         @cookie.authorize_params = get_authorize_params
         redirect to("/login")
       else

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -228,7 +228,7 @@ module Identity
         # If the user is using SSO, have them auth with the SSO service
         @cookie.authorize_params = get_authorize_params
         redirect to("#{Config.sso_base_url}/#{@cookie.sso_entity}")
-      elsif !@cookie.access_token || params[:prompt] == 'login'
+      elsif !@cookie.access_token || params[:prompt] == "login"
         # Have users login if they don't have a session, or the client
         # has requested an explicit login
         @cookie.authorize_params = get_authorize_params

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -1,6 +1,6 @@
 module Identity::Errors
-  class LoginRequired < StandardError
-  end
+  class LoginRequired < StandardError; end
+  class SSORequired < StandardError; end
 
   class PasswordExpired < StandardError
     attr_accessor :message

--- a/lib/identity/errors.rb
+++ b/lib/identity/errors.rb
@@ -1,6 +1,5 @@
 module Identity::Errors
   class LoginRequired < StandardError; end
-  class SSORequired < StandardError; end
 
   class PasswordExpired < StandardError
     attr_accessor :message

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -248,9 +248,7 @@ module Identity::Helpers
       @cookie.refresh_token           = auth["refresh_token"].try(:[], "token")
       @cookie.user_id                 = auth["user"]["id"]
 
-      if Identity::Config.sso_base_url
-        @cookie.sso_entity = auth["sso_entity"]
-      end
+      @cookie.sso_entity = Identity::Config.sso_base_url ? auth["sso_entity"] : nil
 
       # some basic sanity checks
       raise "missing=access_token"  unless @cookie.access_token

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -16,7 +16,14 @@ module Identity
         token = params[:token]
         auth, _ = JWT.decode(token, shared_key)
         write_authentication_to_cookie auth
-        redirect to(Config.dashboard_url)
+
+        # If we have an authorization session, finish it, otherwise send
+        # to dashboard.
+        if @cookie.authorize_params
+          authorize(@cookie.authorize_params)
+        else
+          redirect to(Config.dashboard_url)
+        end
       end
 
       error JWT::DecodeError do

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -17,10 +17,11 @@ module Identity
         auth, _ = JWT.decode(token, shared_key)
         write_authentication_to_cookie auth
 
-        # If we have an authorization session, finish it, otherwise send
-        # to dashboard.
-        if @cookie.authorize_params
-          authorize(@cookie.authorize_params)
+        puts @cookie.authorize_params.inspect
+        # If the user has an active client oauth request, try to finish it.
+        # Otherwise, send the user to dashboard.
+        if auth_params = @cookie.authorize_params
+          call_authorize(auth_params)
         else
           redirect to(Config.dashboard_url)
         end

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -17,7 +17,6 @@ module Identity
         auth, _ = JWT.decode(token, shared_key)
         write_authentication_to_cookie auth
 
-        puts @cookie.authorize_params.inspect
         # If the user has an active client oauth request, try to finish it.
         # Otherwise, send the user to dashboard.
         if auth_params = @cookie.authorize_params

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -107,6 +107,19 @@ describe Identity::Auth do
       assert_match %r{/account/password/reset\z}, last_response.headers["Location"]
     end
 
+    describe "when I have previously logged in via SSO" do
+      let(:rack_env) do
+        { "rack.session" => { "sso_entity" => "initech" } }
+      end
+
+      it "redirects to the sso entity" do
+        post "/oauth/authorize", {client_id: "dashboard"}, rack_env
+
+        assert_equal 302, last_response.status
+        assert_equal "https://sso.heroku.com/initech", last_response.headers["Location"]
+      end
+    end
+
     describe "for a delinquent account" do
       it "redirects to `Location` for a client that does not `ignore_deliquent`" do
         stub_heroku_api do

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -552,6 +552,15 @@ describe Identity::Auth do
           last_response.headers["Location"]
       end
     end
+
+    describe "for users that have previously used an SSO" do
+      it "removes the sso_entity cookie when successfully logging in" do
+        post "/login", { email:  "kerry@heroku.com", password: "abcdefgh" },
+          { "HTTP_X_FORWARDED_FOR" => "8.7.6.5", "rack.session" => { "foo" => "bar", "sso_entity" => "initech"  } }
+
+        assert_equal last_request.env['rack.session']['sso_entity'], nil
+      end
+    end
   end
 
   describe "for accounts with two-factor and sms recovery enabled" do

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -401,27 +401,6 @@ describe Identity::Auth do
         end
       end
     end
-
-    describe "when a user is federated" do
-      before do
-        @authorize_params = { client_id: SecureRandom.uuid }
-      end
-
-      let(:rack_env) do
-        {
-          "rack.session" => {
-            "authorize_params" => MultiJson.encode(@authorize_params),
-            "sso_entity" => "entity"
-          }
-        }
-      end
-
-      it "redirects to the sso page" do
-        get "/login", {}, rack_env
-        follow_redirect!
-        assert_equal "https://sso.heroku.com/entity", last_request.url
-      end
-    end
   end
 
   describe "POST /login" do
@@ -604,27 +583,6 @@ describe Identity::Auth do
       delete "/logout", url: "https://example.com"
       assert_equal 302, last_response.status
       assert_match %r{/login$}, last_response.headers["Location"]
-    end
-
-    describe "when a user is federated" do
-      before do
-        @authorize_params = { client_id: SecureRandom.uuid }
-      end
-
-      let(:rack_env) do
-        {
-          "rack.session" => {
-            "authorize_params" => MultiJson.encode(@authorize_params),
-            "sso_entity" => "entity"
-          }
-        }
-      end
-
-      it "redirects to the sso page" do
-        delete "/logout", {}, rack_env
-        follow_redirect!
-        assert_equal "https://sso.heroku.com/entity", last_request.url
-      end
     end
   end
 

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -113,10 +113,11 @@ describe Identity::Auth do
       end
 
       it "redirects to the sso entity" do
-        post "/oauth/authorize", {client_id: "dashboard"}, rack_env
+        post "/oauth/authorize", { client_id: "dashboard" }, rack_env
 
         assert_equal 302, last_response.status
-        assert_equal "https://sso.heroku.com/initech", last_response.headers["Location"]
+        assert_equal "https://sso.heroku.com/initech",
+                     last_response.headers["Location"]
       end
     end
 
@@ -556,9 +557,10 @@ describe Identity::Auth do
     describe "for users that have previously used an SSO" do
       it "removes the sso_entity cookie when successfully logging in" do
         post "/login", { email:  "kerry@heroku.com", password: "abcdefgh" },
-          { "HTTP_X_FORWARDED_FOR" => "8.7.6.5", "rack.session" => { "foo" => "bar", "sso_entity" => "initech"  } }
+             "HTTP_X_FORWARDED_FOR" => "8.7.6.5",
+             "rack.session" => { "foo" => "bar", "sso_entity" => "initech"  }
 
-        assert_equal last_request.env['rack.session']['sso_entity'], nil
+        assert_equal last_request.env["rack.session"]["sso_entity"], nil
       end
     end
   end

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -10,7 +10,6 @@ describe Identity::Account do
     end
   end
 
-
   def request_session
     last_request.env["rack.session"]
   end
@@ -43,8 +42,8 @@ describe Identity::Account do
     end
 
     describe "token is correct" do
-      let(:jwt_data){{ "foo" => "bar" }}
-      let(:token){ JWT.encode(jwt_data, shared_key, "HS256") }
+      let(:jwt_data) { { "foo" => "bar" } }
+      let(:token) { JWT.encode(jwt_data, shared_key, "HS256") }
 
       describe "there is no active oauth authorization request" do
         it "writes cookies and redirects to dashboard" do
@@ -55,7 +54,8 @@ describe Identity::Account do
           get "/login/external?token=#{token}"
 
           assert_equal 302, last_response.status
-          assert_equal Identity::Config.dashboard_url, last_response.headers["Location"]
+          assert_equal Identity::Config.dashboard_url,
+                       last_response.headers["Location"]
         end
       end
 
@@ -65,10 +65,10 @@ describe Identity::Account do
         end
 
         let(:jwt_data) do
-          { access_token: { token: 'abcd', expires_in: 9000 },
-            session: { id: '456' },
-            user: {id: '123'},
-            sso_entity: 'initech' }
+          { access_token: { token: "abcd", expires_in: 9000 },
+            session: { id: "456" },
+            user: { id: "123" },
+            sso_entity: "initech" }
         end
 
         let(:session_data) do
@@ -76,9 +76,13 @@ describe Identity::Account do
         end
 
         it "finishes the authorization" do
-          get "/login/external", { token: token }, { "rack.session" => session_data }
+          get "/login/external",
+              { token: token },
+              "rack.session" => session_data
+
           assert_equal 302, last_response.status
-          assert_equal "https://dashboard.heroku.com/oauth/callback/heroku?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
+          assert_equal "https://dashboard.heroku.com/oauth/callback/" \
+                       "heroku?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
                        last_response.headers["Location"]
         end
       end

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -10,6 +10,7 @@ describe Identity::Account do
     end
   end
 
+
   def request_session
     last_request.env["rack.session"]
   end
@@ -42,13 +43,13 @@ describe Identity::Account do
     end
 
     describe "token is correct" do
-      let(:cookie_data){{ "foo" => "bar" }}
-      let(:token){ JWT.encode(cookie_data, shared_key, "HS256") }
+      let(:jwt_data){{ "foo" => "bar" }}
+      let(:token){ JWT.encode(jwt_data, shared_key, "HS256") }
 
       describe "there is no active oauth authorization request" do
         it "writes cookies and redirects to dashboard" do
           any_instance_of(Identity::LoginExternal) do |finalize|
-            mock(finalize).write_authentication_to_cookie(cookie_data)
+            mock(finalize).write_authentication_to_cookie(jwt_data)
           end
 
           get "/login/external?token=#{token}"
@@ -59,16 +60,26 @@ describe Identity::Account do
       end
 
       describe "the user has an active oauth authorization request" do
-        let(:rack_env) do
-          { "rack.session" => { "authorize_params" => MultiJson.encode('client_id' => 'abc-123') } }
+        before do
+          stub_heroku_api
         end
 
-        it "writes cookies and calls authorize to finish the authorization" do
-          any_instance_of(Identity::LoginExternal) do |finalize|
-            mock(finalize).write_authentication_to_cookie(cookie_data)
-            mock(finalize).authorize('client_id' => 'abc-123')
-          end
-          get "/login/external?token=#{token}", {}, rack_env
+        let(:jwt_data) do
+          { access_token: { token: 'abcd', expires_in: 9000 },
+            session: { id: '456' },
+            user: {id: '123'},
+            sso_entity: 'initech' }
+        end
+
+        let(:session_data) do
+          { "authorize_params" => MultiJson.encode("client_id" => "dashboard") }
+        end
+
+        it "finishes the authorization" do
+          get "/login/external", { token: token }, { "rack.session" => session_data }
+          assert_equal 302, last_response.status
+          assert_equal "https://dashboard.heroku.com/oauth/callback/heroku?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
+                       last_response.headers["Location"]
         end
       end
     end


### PR DESCRIPTION
- Users that have logged in via SSO can access id.heroku.com/login once again

- Users that have logged in via SSO can now logout of identity.

- POST/GET /oauth/authorize will now authenticate with the SSO provider and redirect back to the originating client for users that have previously logged in via SSO