### PR TITLE
Handle generic client errors for password resets

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -142,7 +142,7 @@ module Identity
             "If you don't receive an email, and it's not in your spam folder "\
             "this could mean you signed up with a different address."
           slim :"account/password/reset", layout: :"layouts/purple"
-        rescue Excon::Errors::NotFound, Excon::Errors::UnprocessableEntity => e
+        rescue Excon::Errors::ClientError => e
           flash[:error] = decode_error(e.response.body)
           redirect to("/account/password/reset")
         end
@@ -170,8 +170,9 @@ module Identity
           flash[:success] = "Your password has been changed."
           redirect to("/login")
         rescue Excon::Errors::NotFound => e
+          status 404
           slim :"account/password/not_found", layout: :"layouts/purple"
-        rescue Excon::Errors::Forbidden, Excon::Errors::UnprocessableEntity => e
+        rescue Excon::Errors::ClientError => e
           Identity.log(
             password_reset_error: true,
             error_body:           e.response.body,

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -106,6 +106,7 @@ module Identity
           flash[:error] = "This link can't be used with your current login."
           redirect to("/login")
         rescue Excon::Errors::NotFound, Excon::Errors::UnprocessableEntity
+          status 404
           slim :"account/email/not_found", layout: :"layouts/purple"
         # it seems that the user's access token is no longer valid, refresh
         rescue Excon::Errors::Unauthorized

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -92,7 +92,7 @@ describe Identity::Account do
         end
       end
       get "/account/email/confirm/c45685917ef644198a0fececa10d479a"
-      assert_equal 200, last_response.status
+      assert_equal 404, last_response.status
       assert_match(/couldn't find that e-mail/, last_response.body)
     end
   end

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -135,8 +135,8 @@ describe Identity::Account do
     it "changes a password and redirects to login" do
       stub_heroku_api
       post "/account/password/reset/c45685917ef644198a0fececa10d479a",
-        password:              "1234567890ab",
-        password_confirmation: "1234567890ab"
+           password:              "1234567890ab",
+           password_confirmation: "1234567890ab"
       assert_equal 302, last_response.status
       assert_match %r{/login$}, last_response.headers["Location"]
     end
@@ -144,12 +144,12 @@ describe Identity::Account do
     it "renders a not found page when there's a 404 error from API" do
       stub_heroku_api do
         post "/password-resets/:token/actions/finalize" do
-          [ 404, MultiJson.encode(message: "Not Found") ]
+          [404, MultiJson.encode(message: "Not Found")]
         end
       end
       post "/account/password/reset/c45685917ef644198a0fececa10d479a",
-        password:              "1234567890ab",
-        password_confirmation: "1234567890ab"
+           password:              "1234567890ab",
+           password_confirmation: "1234567890ab"
       assert_equal 404, last_response.status
     end
 
@@ -157,12 +157,12 @@ describe Identity::Account do
       it "redirects back to reset page when there's a #{error_code} error" do
         stub_heroku_api do
           post "/password-resets/:token/actions/finalize" do
-            [ error_code, MultiJson.encode(message: "a #{error_code} error") ]
+            [error_code, MultiJson.encode(message: "a #{error_code} error")]
           end
         end
         post "/account/password/reset/c45685917ef644198a0fececa10d479a",
-          password:              "1234567890ab",
-          password_confirmation: "1234567890ab"
+              password:              "1234567890ab",
+              password_confirmation: "1234567890ab"
         assert_equal 302, last_response.status
         assert_match %r{/account/password/reset/c45685917ef644198a0fececa10d479a$}, last_response.headers["Location"]
         follow_redirect!

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -135,7 +135,8 @@ describe Identity::Account do
     it "changes a password and redirects to login" do
       stub_heroku_api
       post "/account/password/reset/c45685917ef644198a0fececa10d479a",
-        password: "1234567890ab", password_confirmation: "1234567890ab"
+        password:              "1234567890ab",
+        password_confirmation: "1234567890ab"
       assert_equal 302, last_response.status
       assert_match %r{/login$}, last_response.headers["Location"]
     end
@@ -143,11 +144,12 @@ describe Identity::Account do
     it "renders a not found page when there's a 404 error from API" do
       stub_heroku_api do
         post "/password-resets/:token/actions/finalize" do
-          [ 404, MultiJson.encode({ message: "Not Found" }) ]
+          [ 404, MultiJson.encode(message: "Not Found") ]
         end
       end
       post "/account/password/reset/c45685917ef644198a0fececa10d479a",
-        password: "1234567890ab", password_confirmation: "1234567890ab"
+        password:              "1234567890ab",
+        password_confirmation: "1234567890ab"
       assert_equal 404, last_response.status
     end
 
@@ -155,15 +157,16 @@ describe Identity::Account do
       it "redirects back to reset page when there's a #{error_code} error" do
         stub_heroku_api do
           post "/password-resets/:token/actions/finalize" do
-            [ error_code, MultiJson.encode({ message: "a #{error_code} error" }) ]
+            [ error_code, MultiJson.encode(message: "a #{error_code} error") ]
           end
         end
         post "/account/password/reset/c45685917ef644198a0fececa10d479a",
-          password: "1234567890ab", password_confirmation: "1234567890ab"
+          password:              "1234567890ab",
+          password_confirmation: "1234567890ab"
         assert_equal 302, last_response.status
         assert_match %r{/account/password/reset/c45685917ef644198a0fececa10d479a$}, last_response.headers["Location"]
         follow_redirect!
-        assert_match /a #{error_code} error/, last_response.body
+        assert_match(/a #{error_code} error/, last_response.body)
       end
     end
   end

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -140,6 +140,17 @@ describe Identity::Account do
       assert_match %r{/login$}, last_response.headers["Location"]
     end
 
+    it "renders a not found page when there's a 404 error from API" do
+      stub_heroku_api do
+        post "/password-resets/:token/actions/finalize" do
+          [ 404, MultiJson.encode({ message: "Not Found" }) ]
+        end
+      end
+      post "/account/password/reset/c45685917ef644198a0fececa10d479a",
+        password: "1234567890ab", password_confirmation: "1234567890ab"
+      assert_equal 404, last_response.status
+    end
+
     [ 403, 422 ].each do |error_code|
       it "redirects back to reset page when there's a #{error_code} error" do
         stub_heroku_api do


### PR DESCRIPTION
Fixes #188

Also updates not found pages for password resets and email confirmations to correctly return a 404 status.