### PR TITLE
Clean up the error message decoder

### DIFF
--- a/lib/identity/helpers/api.rb
+++ b/lib/identity/helpers/api.rb
@@ -1,28 +1,16 @@
 module Identity::Helpers
   module API
     def decode_error(body)
-      # error might look like:
-      #   1. { "id":..., "message":... } (V3)
-      #   2. { "error":... } (V2)
-      #   3. [["password","is too short (minimum is 6 characters)"]] (V-Insane)
-      #   4. {"password":["is too short (minimum is 15 characters for Herokai)"]}
-      #   5. "User not found." (V2 404)
+      json = MultiJson.decode(body)
 
-      begin
-        json = MultiJson.decode(body)
-
-        unless json.is_a?(Array)
-          if json.has_key?("error")    ||
-              json.has_key?("message") ||
-              json.has_key?("password")
-            json.map { |e| e.join(" ") }.join("; ")
-          end
-        end
-      rescue MultiJson::DecodeError => e
-        # V2 logs some special cases, like 404s, as plain text
-        log :decode_error, body: body
-        body
+      if json.is_a?(Hash)
+        # use the message field, otherwise munge the errors together
+        json["message"] || json.map { |e| e.join(" ") }.join("; ")
       end
+    rescue MultiJson::DecodeError
+      # V2 logs some special cases, like 404s, as plain text
+      log :decode_error, body: body
+      body
     end
 
     def fetch_sms_number

--- a/test/helpers/api_test.rb
+++ b/test/helpers/api_test.rb
@@ -1,0 +1,31 @@
+require_relative "../test_helper"
+
+describe Identity::Helpers::API do
+  include Identity::Helpers::API
+
+  describe :decode_error do
+    before do
+      stub(self).log
+    end
+
+    it "returns the message value for v3 error messages" do
+      error = {
+        id:      "rate_limit",
+        message: "Please wait a few minutes before making new requests"
+      }
+      assert_equal error[:message], decode_error(MultiJson.encode(error))
+    end
+
+    it "merges any other hashes it gets back" do
+      error = {
+        id:    "wat",
+        error: "something weird"
+      }
+      assert_equal "id wat; error something weird", decode_error(MultiJson.encode(error))
+    end
+
+    it "falls through in the case of decoding errors" do
+      assert_equal "that's some error", decode_error("that's some error")
+    end
+  end
+end

--- a/test/helpers/api_test.rb
+++ b/test/helpers/api_test.rb
@@ -21,7 +21,8 @@ describe Identity::Helpers::API do
         id:    "wat",
         error: "something weird"
       }
-      assert_equal "id wat; error something weird", decode_error(MultiJson.encode(error))
+      assert_equal "id wat; error something weird",
+                   decode_error(MultiJson.encode(error))
     end
 
     it "falls through in the case of decoding errors" do


### PR DESCRIPTION
Now that we're on API v3 endpoints exclusively, we can expect more consistent error messages.

Fixes #183