### PR TITLE
Handle non-2fa forbidden messages on login

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -76,10 +76,14 @@ module Identity
           redirect to("/login")
         # two-factor auth is required
         rescue Excon::Errors::Forbidden => e
-          raise e unless e.response.headers.has_key?("Heroku-Two-Factor-Required")
-          @cookie.email    = user
-          @cookie.password = pass
-          redirect to("/login/two-factor")
+          if e.response.headers.has_key?("Heroku-Two-Factor-Required")
+            @cookie.email    = user
+            @cookie.password = pass
+            redirect to("/login/two-factor")
+          else
+            flash[:error] = decode_error(e.response.body)
+            redirect to("/login")
+          end
         # oauth dance or post-dance authorization was unsuccessful
         rescue Excon::Errors::Unauthorized
           flash[:error] = "There was a problem with your login."

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -515,6 +515,26 @@ describe Identity::Auth do
       assert_match %r{/account/password/reset\z}, last_response.headers["Location"]
     end
 
+    it "redirects to login on forbidded responses that are not two-factor related" do
+      stub_heroku_api do
+        post("/oauth/authorizations") {
+          err = MultiJson.encode({
+            id: "forbidden",
+            message: "Vorboten"
+          })
+          response = OpenStruct.new(body: err, headers: {})
+          raise Excon::Errors::Forbidden.new("Forbidden", nil, response)
+        }
+      end
+
+      post "/login", email: "kerry@heroku.com", password: "abcdefgh"
+      assert_equal 302, last_response.status
+      assert_match %r{/login$}, last_response.headers["Location"]
+      follow_redirect!
+      assert_equal 200, last_response.status
+      assert_match /Vorboten/, last_response.body
+    end
+
     describe "for accounts with two-factor enabled" do
       before do
         stub_heroku_api do

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -515,16 +515,16 @@ describe Identity::Auth do
       assert_match %r{/account/password/reset\z}, last_response.headers["Location"]
     end
 
-    it "redirects to login on forbidded responses that are not two-factor related" do
+    it "redirects to login on forbidden responses that are not 2fa related" do
       stub_heroku_api do
-        post("/oauth/authorizations") {
-          err = MultiJson.encode({
-            id: "forbidden",
+        post("/oauth/authorizations") do
+          err = MultiJson.encode(
+            id:      "forbidden",
             message: "Vorboten"
-          })
+          )
           response = OpenStruct.new(body: err, headers: {})
           raise Excon::Errors::Forbidden.new("Forbidden", nil, response)
-        }
+        end
       end
 
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"


### PR DESCRIPTION
On `POST /login`, we weren't handling 403 FORBIDDEN responses from API that aren't 2fa related, so they show to the user as 500 errors.

Ready for review @heroku/api 