### PR TITLE
Make /signup(/:foo) redirects permanent

### DIFF
--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -225,11 +225,11 @@ module Identity
     end
 
     get "/signup" do
-      redirect_to_signup_app("")
+      redirect_to_signup_app("", 301)
     end
 
     get "/signup/:slug" do |slug|
-      redirect_to_signup_app("/#{params[:slug]}")
+      redirect_to_signup_app("/#{params[:slug]}", 301)
     end
 
     private
@@ -267,14 +267,14 @@ module Identity
     end
 
     # Redirects to the signup app adding a special param
-    def redirect_to_signup_app(next_path)
+    def redirect_to_signup_app(next_path, code=302)
       current_params = CGI.parse(URI.parse(request.fullpath).query.to_s)
       append_params  = { from: 'id' }
       if redirect_url = @cookie.post_signup_url
         append_params["redirect-url"] = redirect_url
       end
       next_params = URI.encode_www_form(current_params.merge(append_params))
-      redirect to("#{Config.signup_url}#{next_path}?#{next_params}")
+      redirect to("#{Config.signup_url}#{next_path}?#{next_params}"), code
     end
   end
 end

--- a/lib/identity/account.rb
+++ b/lib/identity/account.rb
@@ -267,7 +267,7 @@ module Identity
     end
 
     # Redirects to the signup app adding a special param
-    def redirect_to_signup_app(next_path, code=302)
+    def redirect_to_signup_app(next_path, code = 302)
       current_params = CGI.parse(URI.parse(request.fullpath).query.to_s)
       append_params  = { from: 'id' }
       if redirect_url = @cookie.post_signup_url

--- a/test/account_test.rb
+++ b/test/account_test.rb
@@ -174,7 +174,7 @@ describe Identity::Account do
   describe "GET /signup" do
     it "redirects to the root of the signup app" do
       get "/signup"
-      assert_equal 302, last_response.status
+      assert_equal 301, last_response.status
       assert_equal "#{Identity::Config.signup_url}?from=id", last_response.headers["Location"]
     end
   end
@@ -182,7 +182,7 @@ describe Identity::Account do
   describe "GET /signup/:slug" do
     it "redirects to the same slug in the signup app" do
       get "/signup/foo"
-      assert_equal 302, last_response.status
+      assert_equal 301, last_response.status
       assert_equal "#{Identity::Config.signup_url}/foo?from=id",
         last_response.headers["Location"]
     end
@@ -199,7 +199,7 @@ describe Identity::Account do
         "redirect-url" => url
       }
       encoded_params = URI.encode_www_form(expected_params)
-      assert_equal 302, last_response.status
+      assert_equal 301, last_response.status
       assert_equal "#{Identity::Config.signup_url}/foo?#{encoded_params}",
         last_response.headers["Location"]
     end


### PR DESCRIPTION
The `id.h.c/signup -> signup.h.c` redirects have been working like a charm so we can now make them permanent. That should also convince Google to [stop indexing `id.h.c/signup`](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=site%3Aid.heroku.com%20signup).