### PR TITLE
SSO Login

### DIFF
--- a/views/login.slim
+++ b/views/login.slim
@@ -28,5 +28,5 @@
     | New to Heroku? &nbsp;
     span Sign Up
 
-a href="/account/password/reset" Forgot your password?
-a style="margin-left: 100px" href="#{Identity::Config.sso_base_url}/login" Log in via SSO
+a href="#{Identity::Config.sso_base_url}/login" Log in via SSO
+a style="margin-left: 25px" href="/account/password/reset" Forgot your password?

--- a/views/login.slim
+++ b/views/login.slim
@@ -29,4 +29,4 @@
     span Sign Up
 
 a href="/account/password/reset" Forgot your password?
-a style="margin-left: 10px" href="#{Identity::Config.sso_base_url}/login" SSO
+a style="margin-left: 100px" href="#{Identity::Config.sso_base_url}/login" Log in via SSO

--- a/views/login.slim
+++ b/views/login.slim
@@ -29,3 +29,4 @@
     span Sign Up
 
 a href="/account/password/reset" Forgot your password?
+a style="margin-left: 10px" href="#{Identity::Config.sso_base_url}/login" SSO


### PR DESCRIPTION
SSO login adds a small link to initiate single sign-on from the primary login page. It uses the SSO base URL config and appends `/login` to redirect users to the SSO login page.

/cc @dmcinnes 