### PR TITLE
Include API helper in auth helper for #decode_error

### DIFF
--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -1,6 +1,7 @@
 module Identity::Helpers
   module Auth
     include Log
+    include API
 
     # Performs the authorization step of the OAuth dance against the Heroku
     # API.


### PR DESCRIPTION
In certain cases `call_authorize` is called by a class that doesn't have the API helpers, so the call to `decode_error` will fail with a `NoMethodError`.