### PR TITLE
Flush previous session on login

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -52,6 +52,8 @@ module Identity
             user, pass = params[:email], params[:password]
           end
 
+          destroy_existing_session
+
           perform_oauth_dance(user, pass, code)
 
           # in special cases, we may have a redirect URL to go to after login
@@ -304,5 +306,13 @@ module Identity
     rescue URI::InvalidURIError
       false
     end
+
+    def destroy_existing_session
+      # if the cookie already has a session, destroy it first
+      destroy_session if @cookie.session_id
+    rescue Excon::Errors::NotFound
+      # ignore, session is already gone
+    end
+
   end
 end

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -52,7 +52,7 @@ module Identity
             user, pass = params[:email], params[:password]
           end
 
-          destroy_existing_session
+          destroy_session
 
           perform_oauth_dance(user, pass, code)
 
@@ -305,13 +305,6 @@ module Identity
       ].include?(uri.host)
     rescue URI::InvalidURIError
       false
-    end
-
-    def destroy_existing_session
-      # if the cookie already has a session, destroy it first
-      destroy_session unless @cookie.session_id.nil?
-    rescue Excon::Errors::NotFound
-      # ignore, session is already gone
     end
 
   end

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -309,7 +309,7 @@ module Identity
 
     def destroy_existing_session
       # if the cookie already has a session, destroy it first
-      destroy_session if @cookie.session_id
+      destroy_session unless @cookie.session_id.nil?
     rescue Excon::Errors::NotFound
       # ignore, session is already gone
     end

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -306,6 +306,5 @@ module Identity
     rescue URI::InvalidURIError
       false
     end
-
   end
 end

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -118,14 +118,7 @@ module Identity
 
       delete do
         begin
-          api = HerokuAPI.new(user: nil, pass: @cookie.access_token,
-            ip: request.ip, request_ids: request_ids, version: 3)
-          # tells API to destroy the session for Identity's current tokens, and
-          # all the tokens that were provisioned through this session
-          log :destroy_session, session_id: @cookie.session_id do
-            api.delete(path: "/oauth/sessions/#{@cookie.session_id}",
-              expects: [200, 401])
-          end
+          destroy_session
         ensure
           logout
         end

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -264,7 +264,7 @@ module Identity::Helpers
     end
 
     def destroy_session
-      api = HerokuAPI.new(user: nil, pass: @cookie.access_token,
+      api = Identity::HerokuAPI.new(user: nil, pass: @cookie.access_token,
         ip: request.ip, request_ids: request_ids, version: 3)
       # tells API to destroy the session for Identity's current tokens, and
       # all the tokens that were provisioned through this session

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -264,13 +264,14 @@ module Identity::Helpers
     end
 
     def destroy_session
+      return if @cookie.session_id.nil?
       api = Identity::HerokuAPI.new(user: nil, pass: @cookie.access_token,
         ip: request.ip, request_ids: request_ids, version: 3)
       # tells API to destroy the session for Identity's current tokens, and
       # all the tokens that were provisioned through this session
       log :destroy_session, session_id: @cookie.session_id do
         api.delete(path: "/oauth/sessions/#{@cookie.session_id}",
-          expects: [200, 401])
+          expects: [200, 401, 404])
       end
     end
   end

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -262,5 +262,16 @@ module Identity::Helpers
       raise "missing=access_token"  unless @cookie.access_token
       raise "missing=expires_in"    unless @cookie.access_token_expires_at
     end
+
+    def destroy_session
+      api = HerokuAPI.new(user: nil, pass: @cookie.access_token,
+        ip: request.ip, request_ids: request_ids, version: 3)
+      # tells API to destroy the session for Identity's current tokens, and
+      # all the tokens that were provisioned through this session
+      log :destroy_session, session_id: @cookie.session_id do
+        api.delete(path: "/oauth/sessions/#{@cookie.session_id}",
+          expects: [200, 401])
+      end
+    end
   end
 end

--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -265,13 +265,20 @@ module Identity::Helpers
 
     def destroy_session
       return if @cookie.session_id.nil?
-      api = Identity::HerokuAPI.new(user: nil, pass: @cookie.access_token,
-        ip: request.ip, request_ids: request_ids, version: 3)
+      api = Identity::HerokuAPI.new(
+        user:        nil,
+        pass:        @cookie.access_token,
+        ip:          request.ip,
+        request_ids: request_ids,
+        version:     3
+      )
       # tells API to destroy the session for Identity's current tokens, and
       # all the tokens that were provisioned through this session
       log :destroy_session, session_id: @cookie.session_id do
-        api.delete(path: "/oauth/sessions/#{@cookie.session_id}",
-          expects: [200, 401, 404])
+        api.delete(
+          path:    "/oauth/sessions/#{@cookie.session_id}",
+          expects: [200, 401, 404]
+        )
       end
     end
   end

--- a/lib/identity/login_external.rb
+++ b/lib/identity/login_external.rb
@@ -15,6 +15,7 @@ module Identity
       get do
         token = params[:token]
         auth, _ = JWT.decode(token, shared_key)
+        destroy_session
         write_authentication_to_cookie auth
 
         # If the user has an active client oauth request, try to finish it.

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -560,50 +560,50 @@ describe Identity::Auth do
         session_deleted = false
 
         stub_heroku_api do
-          delete "/oauth/sessions/:id" do |id|
+          delete "/oauth/sessions/:id" do
             session_deleted = true
             status 200
           end
         end
 
         post "/login",
-          {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
+             { email: "doug@heroku.com", password: "abcdefgh" }, rack_env
 
         assert session_deleted, "old session must be deleted"
         assert_match /^heroku_user_session=(.+)$/, response_cookie,
-              "it should contain a new session"
+                     "it should contain a new session"
         refute_match /^heroku_user_session=#{session_id}$/, response_cookie,
-              "it should not contain the old session"
+                     "it should not contain the old session"
       end
 
       it "ignores missing sessions" do
         stub_heroku_api do
-          delete "/oauth/sessions/:id" do |id|
+          delete "/oauth/sessions/:id" do
             status 404
           end
         end
 
         post "/login",
-          {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
+             { email: "doug@heroku.com", password: "abcdefgh" }, rack_env
 
         assert_equal 302, last_response.status
         assert_equal Identity::Config.dashboard_url,
-          last_response.headers["Location"]
+                     last_response.headers["Location"]
       end
 
       it "ignores unauthorized sessions" do
         stub_heroku_api do
-          delete "/oauth/sessions/:id" do |id|
+          delete "/oauth/sessions/:id" do
             status 401
           end
         end
 
         post "/login",
-          {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
+             { email: "doug@heroku.com", password: "abcdefgh" }, rack_env
 
         assert_equal 302, last_response.status
         assert_equal Identity::Config.dashboard_url,
-          last_response.headers["Location"]
+                     last_response.headers["Location"]
       end
     end
 

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -546,6 +546,57 @@ describe Identity::Auth do
       assert_match /Vorboten/, last_response.body
     end
 
+    describe "exising sessions" do
+      let(:session_id) { "1234" }
+      let(:rack_env) do
+        {
+          "rack.session" => {
+            "oauth_session_id" => session_id, "access_token" => "5678"
+          }
+        }
+      end
+
+      it "clears an existing session" do
+        post "/login",
+          {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
+
+        assert_match /^heroku_user_session=(.+)$/, response_cookie,
+              "it should contain a new session"
+        refute_match /^heroku_user_session=#{session_id}$/, response_cookie,
+              "it should not contain the old session"
+      end
+
+      it "ignores missing sessions" do
+        stub_heroku_api do
+          delete "/oauth/sessions/:id" do |id|
+            status 404
+          end
+        end
+
+        post "/login",
+          {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
+
+        assert_equal 302, last_response.status
+        assert_equal Identity::Config.dashboard_url,
+          last_response.headers["Location"]
+      end
+
+      it "ignores unauthorized sessions" do
+        stub_heroku_api do
+          delete "/oauth/sessions/:id" do |id|
+            status 401
+          end
+        end
+
+        post "/login",
+          {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
+
+        assert_equal 302, last_response.status
+        assert_equal Identity::Config.dashboard_url,
+          last_response.headers["Location"]
+      end
+    end
+
     describe "for accounts with two-factor enabled" do
       before do
         stub_heroku_api do

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -557,9 +557,19 @@ describe Identity::Auth do
       end
 
       it "clears an existing session" do
+        session_deleted = false
+
+        stub_heroku_api do
+          delete "/oauth/sessions/:id" do |id|
+            session_deleted = true
+            status 200
+          end
+        end
+
         post "/login",
           {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
 
+        assert session_deleted
         assert_match /^heroku_user_session=(.+)$/, response_cookie,
               "it should contain a new session"
         refute_match /^heroku_user_session=#{session_id}$/, response_cookie,

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -569,7 +569,7 @@ describe Identity::Auth do
         post "/login",
           {email: "kerry@heroku.com", password: "abcdefgh"}, rack_env
 
-        assert session_deleted
+        assert session_deleted, "old session must be deleted"
         assert_match /^heroku_user_session=(.+)$/, response_cookie,
               "it should contain a new session"
         refute_match /^heroku_user_session=#{session_id}$/, response_cookie,

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -101,7 +101,7 @@ describe Identity::Account do
           session_deleted = false
 
           stub_heroku_api do
-            delete "/oauth/sessions/:id" do |id|
+            delete "/oauth/sessions/:id" do
               session_deleted = true
               status 200
             end
@@ -116,9 +116,9 @@ describe Identity::Account do
           assert_equal 302, last_response.status
           assert session_deleted, "old session must be deleted"
           assert_match /^heroku_user_session=(.+)$/, response_cookie,
-            "it should contain a new session"
+                       "it should contain a new session"
           refute_match /^heroku_user_session=#{session_id}$/, response_cookie,
-            "it should not contain the old session"
+                       "it should not contain the old session"
         end
       end
     end

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -86,6 +86,47 @@ describe Identity::Account do
                        last_response.headers["Location"]
         end
       end
+
+      describe "existing sessions" do
+        let(:session_id) { "1234" }
+        let(:rack_env) do
+          {
+            "rack.session" => {
+              "oauth_session_id" => session_id, "access_token" => "5678"
+            }
+          }
+        end
+
+        it "clears an existing session" do
+          session_deleted = false
+
+          stub_heroku_api do
+            delete "/oauth/sessions/:id" do |id|
+              session_deleted = true
+              status 200
+            end
+          end
+
+          any_instance_of(Identity::LoginExternal) do |finalize|
+            mock(finalize).write_authentication_to_cookie(jwt_data)
+          end
+
+          get "/login/external?token=#{token}", {}, rack_env
+
+          assert_equal 302, last_response.status
+          assert session_deleted, "old session must be deleted"
+          assert_match /^heroku_user_session=(.+)$/, response_cookie,
+            "it should contain a new session"
+          refute_match /^heroku_user_session=#{session_id}$/, response_cookie,
+            "it should not contain the old session"
+        end
+      end
     end
+  end
+
+  private
+
+  def response_cookie
+    last_response.headers["Set-Cookie"]
   end
 end


### PR DESCRIPTION
This updates the login endpoint to force any previous sessions attached to the browser to explicitly log out before the new user logs in.

Also does the same for login-external requests.

Ready for review @heroku/api 