### PR TITLE
Resolve double color property & prevent white text

### DIFF
--- a/assets/stylesheets/purple/main.scss
+++ b/assets/stylesheets/purple/main.scss
@@ -21,8 +21,7 @@ body {
   .content,
   .content > a {
     margin-bottom: 90px;
-    color: $gray-light;
-    color: fade-out($white, 0.2);
+    color: $gray-dark;
   }
 }
 


### PR DESCRIPTION
##### Before:
<img width="529" alt="screen shot on 2016-03-03 at 17_37_36" src="https://cloud.githubusercontent.com/assets/717867/13503346/d9795f6e-e166-11e5-94c5-2b04aa8388e0.png">
<img width="515" alt="screen shot on 2016-03-03 at 17_37_44" src="https://cloud.githubusercontent.com/assets/717867/13503349/dcfa4acc-e166-11e5-88ca-4d38890ee964.png">

##### After:
<img width="504" alt="screen shot on 2016-03-03 at 17_38_14" src="https://cloud.githubusercontent.com/assets/717867/13503359/e2a6bdb6-e166-11e5-917e-1a45121f5e63.png">