### PR TITLE
Make deny button a clickable link

### DIFF
--- a/views/clients/authorize.slim
+++ b/views/clients/authorize.slim
@@ -41,7 +41,7 @@
           | You can revoke this authorization at any time from your <a href="http://dashboard.heroku.com/account">Dashboard account page</a> or using the <a href="https://github.com/heroku/heroku-oauth">heroku-oauth</a> CLI plugin.
 
     fieldset.split
-      button.btn.btn-default.btn-lg href=@deny_url tabindex="2" Deny
+      a.btn.btn-default.btn-lg href=@deny_url tabindex="2" Deny
       / Note that a value of "Allow" should be kept here so that the
       / server-side component can distinguish a confirmed form post.
       button.btn.btn-primary.btn-lg type="submit" name="authorize" tabindex="1" value="Allow" Allow


### PR DESCRIPTION
Apparently on our client authorization page where we had Accept/Deny buttons, deny button was never working properly.

Instead of acting as a dumb link and redirect user to the failure url via GET request, it was submitting the form with blank POST body and cause identity to respond with an unrelevant error.

This change makes it behave like intended. I also made sure that the page looks exactly the same with that change.