### PR TITLE
Extract deny url into a helper method

### DIFF
--- a/lib/identity/helpers/auth.rb
+++ b/lib/identity/helpers/auth.rb
@@ -218,7 +218,6 @@ module Identity::Helpers
         @cookie.authorize_params = authorize_params
         @client = e.client
         @scope  = @cookie && @cookie.authorize_params["scope"] || nil
-        @deny_url = build_uri(@client["redirect_uri"], error: "access_denied")
         slim :"clients/authorize", layout: :"layouts/purple"
       # for example, "invalid scope"
       rescue Excon::Errors::UnprocessableEntity => e
@@ -242,6 +241,11 @@ module Identity::Helpers
           p["scope"] = p["scope"].split(/[, ]+/).sort.uniq if p["scope"]
         end
       end
+    end
+
+    def client_deny_url
+      base = @client && @client["redirect_uri"] || "https://id.heroku.com"
+      build_uri(base, error: "access_denied")
     end
 
     def write_authentication_to_cookie(auth)

--- a/views/clients/authorize.slim
+++ b/views/clients/authorize.slim
@@ -41,7 +41,7 @@
           | You can revoke this authorization at any time from your <a href="http://dashboard.heroku.com/account">Dashboard account page</a> or using the <a href="https://github.com/heroku/heroku-oauth">heroku-oauth</a> CLI plugin.
 
     fieldset.split
-      a.btn.btn-default.btn-lg href=@deny_url tabindex="2" Deny
+      a.btn.btn-default.btn-lg href=client_deny_url tabindex="2" Deny
       / Note that a value of "Allow" should be kept here so that the
       / server-side component can distinguish a confirmed form post.
       button.btn.btn-primary.btn-lg type="submit" name="authorize" tabindex="1" value="Allow" Allow


### PR DESCRIPTION
Apparently there were 4 places in the code where we've rendered `clients/authorize` template and `@deny_url` was only set in one of them. This PR extracts it into a helper method that allows the template to render the url without instance variable to be set explicitly. It relies on `@client` to be set though.