### PR TITLE
Render 503 on 504 from API

### DIFF
--- a/lib/identity/error_handling.rb
+++ b/lib/identity/error_handling.rb
@@ -6,6 +6,7 @@ module Identity
       # doesn't know how to respond to our V3 "Accept"; display unavailable
       Excon::Errors::NotAcceptable,
       Excon::Errors::ServiceUnavailable,
+      Excon::Errors::GatewayTimeout,
       Excon::Errors::SocketError,
       Excon::Errors::Timeout
     ]


### PR DESCRIPTION
This makes identity render a nice 503 error page instead of 500 when API
request times out and returns 504 for some reason.

Fixes #223