### PR TITLE
discussion-staging.heroku.com is not online anymore

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -290,7 +290,6 @@ module Identity
         "devcenter.heroku.com",
         "devcenter-staging.heroku.com",
         "discussion.heroku.com",
-        "discussion-staging.heroku.com",
       ].include?(uri.host)
     rescue URI::InvalidURIError
       false


### PR DESCRIPTION
Someone can create an app with the name "discussion-staging" and discussion-staging.heroku.com will redirect to discussion-staging.herokuapp.com. That's what I did.

This is a minor issue.