### PR TITLE
Allow Pre-Authorized SSO Users to Continue

### DIFF
--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -248,7 +248,7 @@ module Identity
       # If the user uses SSO and SSO is configured in Identity, continue on to
       # check if their access token is valid.
       return false unless @cookie.sso_entity && Config.sso_base_url
-      return true if !@cookie.access_token
+      return true unless @cookie.access_token
 
       # Check if their current access token is valid.
       api = Identity::HerokuAPI.new(pass: @cookie.access_token,

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -255,8 +255,7 @@ module Identity
                                     ip: request.ip,
                                     request_ids: request_ids,
                                     version: 3)
-      res = api.get(path: "/account")
-      return res.status != 200
+      api.get(path: "/account").status != 200
     end
 
     def flash

--- a/lib/identity/auth.rb
+++ b/lib/identity/auth.rb
@@ -228,8 +228,7 @@ module Identity
     private
 
     def redirect_or_authorize
-      if @cookie.sso_entity && Config.sso_base_url
-        # If the user is using SSO, have them auth with the SSO service
+      if redirect_to_sso?
         @cookie.authorize_params = get_authorize_params
         redirect to("#{Config.sso_base_url}/#{@cookie.sso_entity}")
       elsif !@cookie.access_token || params[:prompt] == "login"
@@ -243,6 +242,21 @@ module Identity
         # Otherwise, perform the authorization
         call_authorize
       end
+    end
+
+    def redirect_to_sso?
+      # If the user uses SSO and SSO is configured in Identity, continue on to
+      # check if their access token is valid.
+      return false unless @cookie.sso_entity && Config.sso_base_url
+      return true if !@cookie.access_token
+
+      # Check if their current access token is valid.
+      api = Identity::HerokuAPI.new(pass: @cookie.access_token,
+                                    ip: request.ip,
+                                    request_ids: request_ids,
+                                    version: 3)
+      res = api.get(path: "/account")
+      return res.status != 200
     end
 
     def flash

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -139,7 +139,8 @@ describe Identity::Auth do
           post "/oauth/authorize", { client_id: "dashboard" }, rack_env
 
           assert_equal 302, last_response.status
-          assert_equal "https://dashboard.heroku.com/oauth/callback/heroku?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
+          assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
+                         "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
                        last_response.headers["Location"]
         end
       end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -30,10 +30,7 @@ describe Identity::Auth do
 
       follow_redirect!
       post "/oauth/authorize", client_id: "dashboard"
-      assert_equal 302, last_response.status
-      assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-        "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
-        last_response.headers["Location"]
+      assert_response_redirects_with_oauth_callback
     end
 
     it "stores and replays an authorization attempt when not logged in" do
@@ -43,20 +40,15 @@ describe Identity::Auth do
 
       follow_redirect!
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"
-      assert_equal 302, last_response.status
-      assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-        "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
-        last_response.headers["Location"]
+      assert_response_redirects_with_oauth_callback
     end
 
     it "passes state" do
       post "/login", email: "kerry@heroku.com", password: "abcdefgh"
 
       post "/oauth/authorize", client_id: "dashboard", state: "my-state"
-      assert_equal 302, last_response.status
-      assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-        "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e&state=my-state",
-        last_response.headers["Location"]
+
+      assert_response_redirects_with_oauth_callback state: "my-state"
     end
 
     it "redirects to login when a user is suspended" do
@@ -138,10 +130,7 @@ describe Identity::Auth do
 
           post "/oauth/authorize", { client_id: "dashboard" }, rack_env
 
-          assert_equal 302, last_response.status
-          assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-                       "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
-                       last_response.headers["Location"]
+          assert_response_redirects_with_oauth_callback
         end
       end
 
@@ -201,11 +190,8 @@ describe Identity::Auth do
         end
         post "/login", email: "kerry@heroku.com", password: "abcdefgh"
         post "/oauth/authorize", client_id: "dashboard"
-        assert_equal 302, last_response.status
-        assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-          "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
-          last_response.headers["Location"]
-        end
+        assert_response_redirects_with_oauth_callback
+      end
     end
 
     describe "for an untrusted client" do
@@ -214,7 +200,7 @@ describe Identity::Auth do
           get("/oauth/clients/:id") {
             MultiJson.encode({
               trusted: false,
-              redirect_uri: "https://dashboard.heroku.com/oauth/callback/heroku"
+              redirect_uri: HerokuAPIStub::AUTHORIZATION[:client][:redirect_uri]
             })
           }
         end
@@ -235,10 +221,7 @@ describe Identity::Auth do
 
         # then again to confirm
         post "/oauth/authorize", authorize: "Allow"
-        assert_equal 302, last_response.status
-        assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-          "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
-          last_response.headers["Location"]
+        assert_response_redirects_with_oauth_callback
       end
 
       it "contains a button that denies access" do
@@ -248,8 +231,8 @@ describe Identity::Auth do
         post "/oauth/authorize", client_id: "untrusted"
 
         #check that the deny link points to the right place
-        assert last_response.body.include? \
-          "https://dashboard.heroku.com/oauth/callback/heroku?error=access_denied"
+        uri = HerokuAPIStub::AUTHORIZATION[:client][:redirect_uri]
+        assert last_response.body.include?("#{uri}?error=access_denied")
       end
 
       it "does not create an authorization if a user confirms via GET" do

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -156,7 +156,7 @@ describe Identity::Auth do
           }
         end
 
-        it "redirects to the sso entity LKSJDFLKJS" do
+        it "redirects to the sso entity" do
           stub_heroku_api do
             get("/account") { status(401) }
           end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -140,7 +140,7 @@ describe Identity::Auth do
 
           assert_equal 302, last_response.status
           assert_equal "https://dashboard.heroku.com/oauth/callback/heroku" +
-                         "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
+                       "?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
                        last_response.headers["Location"]
         end
       end

--- a/test/identity_assertions.rb
+++ b/test/identity_assertions.rb
@@ -1,0 +1,7 @@
+def assert_response_redirects_with_oauth_callback(state: nil)
+  assert_equal 302, last_response.status
+  base = HerokuAPIStub::AUTHORIZATION[:client][:redirect_uri]
+  code = HerokuAPIStub::AUTHORIZATION[:grant][:code]
+  state = !state.nil? ? "&state=#{state}" : ""
+  assert_equal "#{base}?code=#{code}#{state}", last_response.headers["Location"]
+end

--- a/test/login_external_test.rb
+++ b/test/login_external_test.rb
@@ -80,10 +80,7 @@ describe Identity::Account do
               { token: token },
               "rack.session" => session_data
 
-          assert_equal 302, last_response.status
-          assert_equal "https://dashboard.heroku.com/oauth/callback/" \
-                       "heroku?code=454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
-                       last_response.headers["Location"]
+          assert_response_redirects_with_oauth_callback
         end
       end
 

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -98,8 +98,8 @@ class HerokuAPIStub < Sinatra::Base
         redirect_uri:       AUTHORIZATION[:client][:redirect_uri],
       },
       grant: {
-          code:       AUTHORIZATION[:grant][:code],
-          expires_in: 300,
+        code:       AUTHORIZATION[:grant][:code],
+        expires_in: 300,
       },
       refresh_token: nil,
       user: {

--- a/test/service_stubs/heroku_api_stub.rb
+++ b/test/service_stubs/heroku_api_stub.rb
@@ -3,6 +3,13 @@ require "sinatra/base"
 require "sinatra/namespace"
 
 class HerokuAPIStub < Sinatra::Base
+  AUTHORIZATION = {
+    client: {
+      redirect_uri: "https://dashboard.heroku.com/oauth/callback/heroku"
+    },
+    grant: { code: "454118bc-902d-4a2c-9d5b-e2a2abb91f6e" }
+  }
+
   register Sinatra::Namespace
 
   configure do
@@ -88,10 +95,10 @@ class HerokuAPIStub < Sinatra::Base
         id:                 123,
         ignores_delinquent: false,
         name:               "dashboard",
-        redirect_uri:       "https://dashboard.heroku.com/oauth/callback/heroku",
+        redirect_uri:       AUTHORIZATION[:client][:redirect_uri],
       },
       grant: {
-          code:       "454118bc-902d-4a2c-9d5b-e2a2abb91f6e",
+          code:       AUTHORIZATION[:grant][:code],
           expires_in: 300,
       },
       refresh_token: nil,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ require "webmock/minitest"
 
 require_relative "../lib/identity"
 require_relative "service_stubs"
+require_relative "identity_assertions"
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
SSO users that already authorized via their IdP experience an issue
where they must perform the oauth dance twice, causing them to log
into their IdP twice. This checks if an SSO user's token is already
valid and lets them continue without having to log in a second time.