### PR TITLE
Revert "Remove user id from cookie"

### DIFF
--- a/lib/identity/heroku_cookie.rb
+++ b/lib/identity/heroku_cookie.rb
@@ -61,6 +61,7 @@ module Identity
       def user_info
         {
           user: {
+            id: @cookie.user_id,
             email: @cookie.user_email,
             full_name: @cookie.user_full_name
           }

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -498,6 +498,7 @@ describe Identity::Auth do
         Identity::Config.heroku_root_domain_cookie_encryption_key)
       payload = coder.decode(cipher)
 
+      assert_equal "06dcaabe-f7cd-473a-aa10-df54045ff69c", payload["user"]["id"]
       assert_equal "email@heroku.com", payload["user"]["email"]
       assert_equal "Full Name", payload["user"]["full_name"]
     end

--- a/test/cookie_coder_test.rb
+++ b/test/cookie_coder_test.rb
@@ -7,6 +7,7 @@ describe Identity::CookieCoder do
   it "encryptes a cookie, then descrypts a cookie" do
     data = {
       user: {
+        id: "1234",
         email: "example@herou.com",
         full_name: "Full Name"
       }
@@ -20,6 +21,7 @@ describe Identity::CookieCoder do
   it "encrypts with the first given key" do
     data = {
       user: {
+        id: "1234",
         email: "example@herou.com",
         full_name: "Full Name"
       }
@@ -33,6 +35,7 @@ describe Identity::CookieCoder do
   it "enables graceful encryption key rotation" do
     data = {
       user: {
+        id: "1234",
         email: "example@herou.com",
         full_name: "Full Name"
       }


### PR DESCRIPTION
This reverts commit 0317fa67d6c0c7a63d4ccd5240e14af4b089661f.

We're adding the user_id to the cookie used by Glostick (introduced [here](https://github.com/heroku/identity/pull/206)). This will give us greater confidence using the correct user records when tailoring content to specific users. An example that is a WIP is showing relevant Dev Center articles upon (logged in) users visiting the Dev Center homepage.

/cc @heroku/marketing-web-ops 
